### PR TITLE
Add support for net6.0 (#24)

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer.shared.cs
@@ -2,7 +2,8 @@
 
 public partial class AudioPlayer : IAudioPlayer
 {
-    public event EventHandler? PlaybackEnded;
+#pragma warning disable CS0067
+	public event EventHandler? PlaybackEnded;
 
     ~AudioPlayer()
     {
@@ -15,4 +16,36 @@ public partial class AudioPlayer : IAudioPlayer
 
         GC.SuppressFinalize(this);
     }
+
+#if (NET6_0 && !ANDROID && !IOS && !MACCATALYST && !WINDOWS)
+
+	public AudioPlayer(Stream audioStream) {}
+
+	public AudioPlayer(string fileName) {}
+
+	protected virtual void Dispose(bool disposing) {}
+
+	public double Duration { get; }
+
+	public double CurrentPosition { get; }
+
+	public double Volume { get; set; }
+
+	public double Balance { get; set; }
+
+	public bool IsPlaying { get; }
+
+	public bool Loop { get; set; }
+
+	public bool CanSeek { get; }
+
+	public void Play() {}
+
+	public void Pause() {}
+
+	public void Stop() {}
+
+	public void Seek(double position) {}
+
+#endif
 }

--- a/src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj
+++ b/src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst;net6.0</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->


### PR DESCRIPTION
Added net6.0 to the TargetFrameworks. Added a do nothing implementation to AudioPlayer.shared.cs that is only considered if NET6_0 is being targeted specifically.