### PR TITLE
generic conditional compilation independent of .NET 6.0 target framework

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer.net.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer.net.cs
@@ -1,0 +1,32 @@
+﻿namespace Plugin.Maui.Audio;
+
+partial class AudioPlayer : IAudioPlayer
+{
+	public AudioPlayer(Stream audioStream) { }
+
+	public AudioPlayer(string fileName) { }
+
+	protected virtual void Dispose(bool disposing) { }
+
+	public double Duration { get; }
+
+	public double CurrentPosition { get; }
+
+	public double Volume { get; set; }
+
+	public double Balance { get; set; }
+
+	public bool IsPlaying { get; }
+
+	public bool Loop { get; set; }
+
+	public bool CanSeek { get; }
+
+	public void Play() { }
+
+	public void Pause() { }
+
+	public void Stop() { }
+
+	public void Seek(double position) { }
+}

--- a/src/Plugin.Maui.Audio/AudioPlayer.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer.shared.cs
@@ -17,36 +17,4 @@ public partial class AudioPlayer : IAudioPlayer
 
         GC.SuppressFinalize(this);
     }
-
-#if (NET6_0 && !ANDROID && !IOS && !MACCATALYST && !WINDOWS)
-
-	public AudioPlayer(Stream audioStream) {}
-
-	public AudioPlayer(string fileName) {}
-
-	protected virtual void Dispose(bool disposing) {}
-
-	public double Duration { get; }
-
-	public double CurrentPosition { get; }
-
-	public double Volume { get; set; }
-
-	public double Balance { get; set; }
-
-	public bool IsPlaying { get; }
-
-	public bool Loop { get; set; }
-
-	public bool CanSeek { get; }
-
-	public void Play() {}
-
-	public void Pause() {}
-
-	public void Stop() {}
-
-	public void Seek(double position) {}
-
-#endif
 }

--- a/src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj
+++ b/src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj
@@ -36,30 +36,36 @@
 		<PackageIcon>icon.png</PackageIcon>
 	</PropertyGroup>
 
-	<ItemGroup Condition="$(TargetFramework.StartsWith('net6.0-ios')) != true AND $(TargetFramework.StartsWith('net6.0-maccatalyst')) != true ">
+	<!-- iOS & MacCatalyst -->
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net')) == true AND $(TargetFramework.Contains('-ios')) != true AND $(TargetFramework.Contains('-maccatalyst')) != true ">
 		<Compile Remove="**\**\*.ios.cs" />
 		<None Include="**\**\*.ios.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
 		<Compile Remove="**\ios\**\*.cs" />
 		<None Include="**\ios\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
-	</ItemGroup>
-
-	<ItemGroup Condition="$(TargetFramework.StartsWith('net6.0-ios')) != true AND $(TargetFramework.StartsWith('net6.0-maccatalyst')) != true">
 		<Compile Remove="**\*.macios.cs" />
 		<None Include="**\*.macios.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
 		<Compile Remove="**\macios\**\*.cs" />
 		<None Include="**\macios\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
 	</ItemGroup>
-	<ItemGroup Condition="$(TargetFramework.StartsWith('net6.0-android')) != true ">
+	<!-- Android -->
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net')) == true AND $(TargetFramework.Contains('-android')) != true">
 		<Compile Remove="**\**\*.android.cs" />
 		<None Include="**\**\*.android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
 		<Compile Remove="**\android\**\*.cs" />
 		<None Include="**\android\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
 	</ItemGroup>
-	<ItemGroup Condition="$(TargetFramework.Contains('-windows')) != true ">
+	<!-- Windows -->
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net')) == true AND $(TargetFramework.Contains('-windows')) != true">
 		<Compile Remove="**\*.windows.cs" />
 		<None Include="**\*.windows.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
 		<Compile Remove="**\windows\**\*.cs" />
 		<None Include="**\windows\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+	<!-- .NET (generic) -->
+	<ItemGroup Condition="!($(TargetFramework.StartsWith('net')) == true AND $(TargetFramework.EndsWith('.0')) == true AND $(TargetFramework.Contains('-')) != true)">
+		<!-- e.g net6.0 or net7.0 (and higher) -->
+		<Compile Remove="**\*.net.cs" />
+		<None Include="**\*.net.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
I have reworked the .NET 6.0 target framework fix to be future proof and work with .NET 7.0 as well. This way, only the actual TargetFrameworks need to be updated and not all the other places where the targets are used for conditional compilation.