### PR TITLE
Unify/remove media position reset on Play

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer.android.cs
@@ -127,7 +127,6 @@ partial class AudioPlayer : IAudioPlayer
         if (IsPlaying)
         {
             Pause();
-            Seek(0);
         }
 
         player.Start();

--- a/src/Plugin.Maui.Audio/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer.macios.cs
@@ -76,7 +76,7 @@ partial class AudioPlayer : IAudioPlayer
     {
         if (player.Playing)
         {
-            player.CurrentTime = 0;
+            player.Pause();
         }
         else
         {

--- a/src/Plugin.Maui.Audio/AudioPlayer.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer.windows.cs
@@ -76,7 +76,6 @@ partial class AudioPlayer : IAudioPlayer
 		if (player.PlaybackSession.PlaybackState == MediaPlaybackState.Playing)
 		{
 			Pause();
-			Seek(0);
 		}
 
 		player.Play();


### PR DESCRIPTION
I noticed that when you call Play, the position would be reset.

In my mind, resetting the position is something that belongs to the Stop. When I pause I want to be able to press play again to resume playing. Only when I press stop I expect playback to be reset whenever I start again.

Additionally, I think for iOS there was inconsistent behavior when Play was called it didn't pause the playback as it does on other platforms.