### PR TITLE
Add README to NuGet Package

### DIFF
--- a/src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj
+++ b/src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj
@@ -34,6 +34,7 @@
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<DebugType>portable</DebugType>
 		<PackageIcon>icon.png</PackageIcon>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 
 	<!-- iOS & MacCatalyst -->
@@ -76,5 +77,6 @@
 	<!-- Package additions -->
 	<ItemGroup>
 		<None Include="..\..\nuget.png" PackagePath="icon.png" Pack="true" />
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
As per #95 added the required tags to the csproj to include the README in the NuGet package and show it on nuget.org

Fixes #95