### PR TITLE
Swap to using MixWithOthers for the AVAudioSessionCategoryOptions

### DIFF
--- a/samples/Plugin.Maui.Audio.Sample/MauiProgram.cs
+++ b/samples/Plugin.Maui.Audio.Sample/MauiProgram.cs
@@ -25,7 +25,7 @@ public static class MauiProgram
 #if IOS || MACCATALYST
 					recordingOptions.Category = AVFoundation.AVAudioSessionCategory.Record;
 					recordingOptions.Mode = AVFoundation.AVAudioSessionMode.Default;
-					recordingOptions.CategoryOptions = AVFoundation.AVAudioSessionCategoryOptions.DefaultToSpeaker;
+					recordingOptions.CategoryOptions = AVFoundation.AVAudioSessionCategoryOptions.MixWithOthers;
 #endif
 				})
 			.ConfigureFonts(fonts =>


### PR DESCRIPTION
Corrects the usage of the CategoryOptions when recording on iOS