### PR TITLE
Silence detection

### DIFF
--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
@@ -19,6 +19,7 @@ partial class AudioRecorder : IAudioRecorder
 	readonly AudioRecorderOptions options;
 	int channels;
 	int bitDepth;
+
 	byte[]? audioData;
     byte[]? audioDataChunk;
 
@@ -89,8 +90,6 @@ partial class AudioRecorder : IAudioRecorder
 		this.channels = channels == ChannelIn.Mono ? 1 : 2;
 		this.bufferSize = AudioRecord.GetMinBufferSize(sampleRate, channels, encoding);
 
-		audioData = new byte[bufferSize];
-
 		return new AudioRecord(AudioSource.Mic, sampleRate, channels, encoding, bufferSize);
 	}
 
@@ -160,6 +159,8 @@ partial class AudioRecorder : IAudioRecorder
 		{
 			throw new FileLoadException($"unable to create a new file: {ex.Message}");
 		}
+
+		audioData = new byte[bufferSize];
 
 		if (audioRecord is not null && outputStream is not null)
 		{
@@ -290,15 +291,19 @@ partial class AudioRecorder : IAudioRecorder
 
 	byte[]? GetAudioDataChunk()
 	{
-		byte[] buffer = new byte[bufferSize];
-
 		audioDataChunk ??= new byte[bufferSize];
-
-		if (!audioDataChunk.SequenceEqual(audioData))
+		
+		if (audioData is not null)
 		{
-			Array.Copy(audioData, buffer, bufferSize);
-			audioDataChunk = buffer;
-			return buffer;
+			if (!audioDataChunk.SequenceEqual(audioData))
+			{
+				Array.Copy(audioData, audioDataChunk, bufferSize);
+				return audioDataChunk;
+			}
+			else
+			{
+				return null;
+			}
 		}
 		else
 		{

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
@@ -47,6 +47,7 @@ partial class AudioRecorder : IAudioRecorder
 			audioData = new byte[bufferSize];
 
 			audioRecord.StartRecording();
+			SoundDetected = false;
 			Task.Run(() => WriteAudioDataToFile());
 		}
 		return Task.CompletedTask;
@@ -214,14 +215,11 @@ partial class AudioRecorder : IAudioRecorder
 
 	public async Task DetectSilenceAsync(double silenceThreshold, int silenceDuration)
 	{
-		lastSoundDetectedTime = default;
-		noiseLevel = 0;
-		readingsComplete = false;
+		InitDetectSilence();
 
 		await Task.Run(() =>
 		{
 			byte[] buffer = new byte[bufferSize];
-			bool readingsComplete = false;
 
 			while (this.IsRecording)
 			{

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.macios.cs
@@ -105,4 +105,9 @@ partial class AudioRecorder : IAudioRecorder
 	{
 		finishedRecordingCompletionSource?.SetResult(true);
 	}
+
+	public Task DetectSilenceAsync(double silenceThreshold, int silenceDuration)
+	{
+		throw new NotImplementedException();
+	}
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.macios.cs
@@ -106,8 +106,5 @@ partial class AudioRecorder : IAudioRecorder
 		finishedRecordingCompletionSource?.SetResult(true);
 	}
 
-	public Task DetectSilenceAsync(double silenceThreshold, int silenceDuration)
-	{
-		throw new NotImplementedException();
-	}
+	byte[]? GetAudioDataChunk() => throw new NotImplementedException();
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.net.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.net.cs
@@ -10,14 +10,11 @@ partial class AudioRecorder : IAudioRecorder
 
 	public bool IsRecording => false;
 
-	public Task DetectSilenceAsync(double silenceThreshold, int silenceDuration)
-	{
-		throw new NotImplementedException();
-	}
-
 	public Task StartAsync() => Task.CompletedTask;
 
 	public Task StartAsync(string filePath) => Task.CompletedTask;
 
 	public Task<IAudioSource> StopAsync() => Task.FromResult<IAudioSource>(new EmptyAudioSource());
+
+	byte[]? GetAudioDataChunk() => throw new NotImplementedException();
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.net.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.net.cs
@@ -10,6 +10,11 @@ partial class AudioRecorder : IAudioRecorder
 
 	public bool IsRecording => false;
 
+	public Task DetectSilenceAsync(double silenceThreshold, int silenceDuration)
+	{
+		throw new NotImplementedException();
+	}
+
 	public Task StartAsync() => Task.CompletedTask;
 
 	public Task StartAsync(string filePath) => Task.CompletedTask;

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
@@ -13,6 +13,9 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 
 	public async Task DetectSilenceAsync(double silenceThreshold, int silenceDuration, CancellationToken cancellationToken)
 	{
+		ArgumentOutOfRangeException.ThrowIfLessThan(silenceThreshold, 1);
+		ArgumentOutOfRangeException.ThrowIfNegative(silenceDuration);
+
 		readingsComplete = false;
 		noiseLevel = 0;
 		firstNoiseDetectedTime = default;

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
@@ -1,0 +1,82 @@
+﻿using System.Diagnostics;
+
+namespace Plugin.Maui.Audio;
+
+partial class AudioRecorder
+{
+	DateTime lastSoundDetectedTime = default;
+	double noiseLevel = 0;
+	bool readingsComplete = false;
+
+	public bool DetectSilence(byte[] audioData, double silenceThreshold, int silenceDuration)
+	{
+		if (!readingsComplete)
+		{
+			readingsComplete = CheckIfReadingsComplete(audioData);
+		}
+		else if (noiseLevel == 0)
+		{
+			noiseLevel = CalculateNormalizedRMS(audioData);
+			//Debug.WriteLine($"Noise level: {noiseLevel}");
+		}
+		else
+		{
+			double audioLevel = CalculateNormalizedRMS(audioData);
+
+			if (audioLevel < noiseLevel)
+			{
+				noiseLevel = audioLevel;
+			}
+
+			if (audioLevel < silenceThreshold * noiseLevel)
+			{
+				if (lastSoundDetectedTime == default)
+				{
+					lastSoundDetectedTime = DateTime.UtcNow;
+				}
+				else if ((DateTime.UtcNow - lastSoundDetectedTime).TotalMilliseconds >= silenceDuration)
+				{
+					Debug.WriteLine("Silence detected.");
+					return true;
+				}
+			}
+			else
+			{
+				lastSoundDetectedTime = default;
+			}
+		}
+
+		return false;
+	}
+
+	double CalculateNormalizedRMS(byte[] buffer)
+	{
+		double sampleSquareSum = 0;
+		for (int i = 0; i < buffer.Length; i += 2)
+		{
+			short sample = BitConverter.ToInt16(buffer, i);
+			sampleSquareSum += sample * sample;
+		}
+
+		double rootMeanSquare = Math.Sqrt(sampleSquareSum / (buffer.Length / 2));
+		double normalizedRMS = rootMeanSquare / short.MaxValue;
+		Debug.WriteLine($"RMS: {normalizedRMS} | Noise: {noiseLevel}");
+		return normalizedRMS;
+	}
+
+	/// <summary>
+	/// First sets of data after starting recoding are always zeros. They are followed by one incomplete set that have zeros at the beginning.
+	/// Checking completeness of data is crucial beacuse the first complete audio data set is used to define background noise level.
+	/// </summary>
+	bool CheckIfReadingsComplete(byte[] data)
+	{
+		int sum = default;
+
+		for (int i = 0; i < 100; i++)
+		{
+			sum += data[i];
+		}
+
+		return sum > 0;
+	}
+}

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
@@ -2,7 +2,7 @@
 
 namespace Plugin.Maui.Audio;
 
-partial class AudioRecorder // TODO: add exception treshold < 1
+partial class AudioRecorder
 {
 	bool readingsComplete;
 	double noiseLevel;
@@ -60,7 +60,7 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 
 	bool DetectSilence(byte[] audioData, double silenceThreshold, int silenceDuration)
 	{
-		double minimumNoiseLevel = 0.01;
+		double minimumNoiseLevel = 0.005;
 
 		if (!readingsComplete)
 		{

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
@@ -57,6 +57,8 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 
 	bool DetectSilence(byte[] audioData, double silenceThreshold, int silenceDuration)
 	{
+		double minimumNoiseLevel = 0.01;
+
 		if (!readingsComplete)
 		{
 			readingsComplete = CheckIfReadingsComplete(audioData);
@@ -64,13 +66,19 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 		else if (noiseLevel == 0)
 		{
 			noiseLevel = CalculateNormalizedRMS(audioData);
+
+			if (noiseLevel < minimumNoiseLevel)
+			{
+				noiseLevel = minimumNoiseLevel;
+			}
+
 			firstNoiseDetectedTime = DateTime.UtcNow;
 		}
 		else
 		{
 			double audioLevel = CalculateNormalizedRMS(audioData);
 
-			if (audioLevel < noiseLevel)
+			if (audioLevel < noiseLevel && audioLevel > minimumNoiseLevel)
 			{
 				noiseLevel = audioLevel;
 			}

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
@@ -24,7 +24,7 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 			await Task.Run(() =>
 			{
 #if WINDOWS
-				fileStream = GetFileStream();
+				audioFileStream = GetFileStream();
 				audioChunkNumber = 1;
 #endif
 				while (IsRecording)
@@ -50,7 +50,7 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 		finally
 		{
 #if WINDOWS
-			fileStream?.Dispose();
+			audioFileStream?.Dispose();
 #endif
 		}
 	}

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.shared.cs
@@ -6,7 +6,7 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 {
 	bool readingsComplete;
 	double noiseLevel;
-	DateTime noiseDetectedTime;
+	DateTime firstNoiseDetectedTime;
 	DateTime lastSoundDetectedTime;
 
 	public bool SoundDetected { get; private set; }
@@ -15,7 +15,7 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 	{
 		readingsComplete = false;
 		noiseLevel = 0;
-		noiseDetectedTime = default;
+		firstNoiseDetectedTime = default;
 		lastSoundDetectedTime = default;
 
 		try
@@ -64,7 +64,7 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 		else if (noiseLevel == 0)
 		{
 			noiseLevel = CalculateNormalizedRMS(audioData);
-			noiseDetectedTime = DateTime.UtcNow;
+			firstNoiseDetectedTime = DateTime.UtcNow;
 		}
 		else
 		{
@@ -86,7 +86,7 @@ partial class AudioRecorder // TODO: add exception treshold < 1
 						return true;
 					}
 				}
-				else if ((DateTime.UtcNow - noiseDetectedTime).TotalMilliseconds >= silenceDuration)
+				else if ((DateTime.UtcNow - firstNoiseDetectedTime).TotalMilliseconds >= silenceDuration)
 				{
 					Debug.WriteLine("No sound detected.");
 

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
@@ -166,7 +166,7 @@ partial class AudioRecorder : IAudioRecorder
 		uint bitRate = encodingProfile.Audio.Bitrate;
 		uint bufferSize;
 
-		bufferSize = bitRate != 0 ? bitRate / 8 / 10 : 192_000 / 10; // TODO: calculate bitrate and test with headphones
+		bufferSize = bitRate != 0 ? bitRate / 8 / 10 : 256_000 / 8 / 10; // MediaCapture do not put data about bit rate in EncodingProfile.Audio.Bitrate when AudioEncodingQuality.Auto
 
 		byte[] buffer = new byte[bufferSize];
 

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
@@ -8,7 +8,7 @@ namespace Plugin.Maui.Audio;
 partial class AudioRecorder : IAudioRecorder
 {
 	MediaCapture? mediaCapture;
-	readonly MediaEncodingProfile encodingProfile = MediaEncodingProfile.CreateWav(AudioEncodingQuality.Auto);
+	readonly MediaEncodingProfile encodingProfile = MediaEncodingProfile.CreateWav(AudioEncodingQuality.Medium);
 	string audioFilePath = string.Empty;
 	StorageFile? fileOnDisk;
 

--- a/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
@@ -30,4 +30,12 @@ public interface IAudioRecorder
 	/// Stop recording and return the <see cref="IAudioSource"/> instance with the recording data.
 	///</Summary>
 	Task<IAudioSource> StopAsync();
+
+	/// <summary>
+	/// Detects silence that persists for a <paramref name="silenceDuration"/> ms period of time.
+	/// The silence is when audio level is beyond <paramref name="silenceThreshold"/> multiplied by lowest detected audio level.
+	/// </summary>
+	/// <param name="silenceThreshold"></param>
+	/// <param name="silenceDuration"></param>
+	Task DetectSilenceAsync(double silenceThreshold = 2, int silenceDuration = 1500);
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
@@ -15,6 +15,11 @@ public interface IAudioRecorder
 	///</Summary>
 	bool IsRecording { get; }
 
+	/// <Summary>
+	/// Gets whether a sound (other than the ambient) was detected. Works only when DetectSilenceAsync fired.
+	/// </Summary>
+	bool SoundDetected { get; }
+
 	///<Summary>
 	/// Start recording audio to disk in a randomly generated file.
 	///</Summary>
@@ -31,11 +36,11 @@ public interface IAudioRecorder
 	///</Summary>
 	Task<IAudioSource> StopAsync();
 
-	/// <summary>
+	/// <Summary>
 	/// Detects silence that persists for a <paramref name="silenceDuration"/> ms period of time.
 	/// The silence is when audio level is beyond <paramref name="silenceThreshold"/> multiplied by lowest detected audio level.
-	/// </summary>
+	/// </Summary>
 	/// <param name="silenceThreshold"></param>
 	/// <param name="silenceDuration"></param>
-	Task DetectSilenceAsync(double silenceThreshold = 2, int silenceDuration = 1500);
+	Task DetectSilenceAsync(double silenceThreshold = 3, int silenceDuration = 1500);
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
@@ -42,5 +42,5 @@ public interface IAudioRecorder
 	/// </Summary>
 	/// <param name="silenceThreshold"></param>
 	/// <param name="silenceDuration"></param>
-	Task DetectSilenceAsync(double silenceThreshold = 3, int silenceDuration = 1500);
+	Task DetectSilenceAsync(double silenceThreshold = 3, int silenceDuration = 1500, CancellationToken cancellationToken = default);
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
@@ -55,5 +55,5 @@ public interface IAudioRecorder
 	/// </Summary>
 	/// <param name="silenceThreshold"></param>
 	/// <param name="silenceDuration"></param>
-	Task DetectSilenceAsync(double silenceThreshold = 3, int silenceDuration = 1000, CancellationToken cancellationToken = default);
+	Task DetectSilenceAsync(double silenceThreshold = 2, int silenceDuration = 1000, CancellationToken cancellationToken = default);
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
@@ -42,5 +42,5 @@ public interface IAudioRecorder
 	/// </Summary>
 	/// <param name="silenceThreshold"></param>
 	/// <param name="silenceDuration"></param>
-	Task DetectSilenceAsync(double silenceThreshold = 3, int silenceDuration = 1500, CancellationToken cancellationToken = default);
+	Task DetectSilenceAsync(double silenceThreshold = 3, int silenceDuration = 1000, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
Silence detection implementation for Windows and Android.

A `DetectSilenceAsync` should be fired after starting recording audio. The `DetectSilenceAsync` task is completed when silence is detected. A silence is when the recorded audio level is less or equal to `silenceTreshold` multiplied by noise* for `silenceDuration` period of time.  

The `SoundDetected` property is set to false after each start of recording. When a sound greater than `silenceTreshold` multiplied by noise is detected the `SoundDetected` is set to true.

Most of the code is shared. The only platform specific part is the `GetAudioChunk` method which is responsible for providing a stream of audio data samples to the `DetectSilence` method.

\* noise is the lowest detected audio level detected during recording but not lower than 0.01 (the values are normalized)