### PR TITLE
Fixed CurrentPosition on android platform

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -285,6 +285,10 @@ partial class AudioPlayer : IAudioPlayer
 	{
 		player.SeekTo((int)(position * 1000D));
 		stopwatch = new AudioStopwatch(TimeSpan.FromSeconds(position), Speed);
+        if (IsPlaying)
+        {
+            stopwatch.Start();
+        }
 	}
 
 	void SetVolume(double volume, double balance)


### PR DESCRIPTION
I noticed that the CurrentPosition is not updated when I seek an audio position while the audio is playing. The stopwatch may need to start automatically after seeking the position while the audio is playing.