### PR TITLE
Fix android crash Dispose() call in PlaybackEnded event

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -304,6 +304,11 @@ partial class AudioPlayer : IAudioPlayer
 	{
 		PlaybackEnded?.Invoke(this, e);
 
+		if (isDisposed)
+		{
+			return;
+		}
+
 		isPlaying = player.IsPlaying;
 
 		//this improves stability on older devices but has minor performance impact
@@ -326,6 +331,7 @@ partial class AudioPlayer : IAudioPlayer
 		if (disposing)
 		{
 			player.Completion -= OnPlaybackEnded;
+			player.Reset();
 			player.Release();
 			player.Dispose();
 			DeleteFile(cachePath);

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -302,13 +302,6 @@ partial class AudioPlayer : IAudioPlayer
 
 	void OnPlaybackEnded(object? sender, EventArgs e)
 	{
-		PlaybackEnded?.Invoke(this, e);
-
-		if (isDisposed)
-		{
-			return;
-		}
-
 		isPlaying = player.IsPlaying;
 
 		//this improves stability on older devices but has minor performance impact
@@ -319,6 +312,8 @@ partial class AudioPlayer : IAudioPlayer
 			player.Stop();
 			player.Prepare();
 		}
+
+		PlaybackEnded?.Invoke(this, e);
 	}
 
 	protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
Allow the creation of a IAudioPlayer that will be disposed imediatly after ending.

```C#
IAudioPlayer player = _audioManager.CreatePlayer(await FileSystem.OpenAppPackageFileAsync("sound.mp3");
player.PlaybackEnded += (s, e) =>
{
    player.Dispose();
};
player.Play();
```