### PR TITLE
Fix the issue of the audio recording segment repeating at the end on the Android platform

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -285,6 +285,10 @@ partial class AudioPlayer : IAudioPlayer
 	{
 		player.SeekTo((int)(position * 1000D));
 		stopwatch = new AudioStopwatch(TimeSpan.FromSeconds(position), Speed);
+        if (IsPlaying)
+        {
+            stopwatch.Start();
+        }
 	}
 
 	void SetVolume(double volume, double balance)

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
@@ -162,9 +162,8 @@ partial class AudioRecorder : IAudioRecorder
 		{
 			while (audioRecord.RecordingState == RecordState.Recording)
 			{
-				audioRecord.Read(data, 0, bufferSize);
-
-				outputStream.Write(data);
+				var read = audioRecord.Read(data, 0, bufferSize);
+				outputStream.Write(data, 0, read);
 			}
 
 			outputStream.Close();


### PR DESCRIPTION
I noticed that on some Android devices, the recording would repeat a segment at the end. I believe this issue arises because `audioRecord.Read` may not always fully fill the buffer, especially at the end of the recording. If you write the last buffer directly to `outputStream`, the last part of the second-to-last one will be written twice, resulting in repeated audio segments.
https://github.com/jfversluis/Plugin.Maui.Audio/blob/2b53e193033a09b3c570ccec0d82a1817aacbb68/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs#L165-L167
Maybe we should only write the buffer that was read by audioRecord.
```cs
var read = audioRecord.Read(data, 0, bufferSize);
outputStream.Write(data, 0, read);
```
Related issues: https://github.com/jfversluis/Plugin.Maui.Audio/issues/121