### PR TITLE
Make recording in-place and fix the WAV header on the Android platform

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -285,6 +285,10 @@ partial class AudioPlayer : IAudioPlayer
 	{
 		player.SeekTo((int)(position * 1000D));
 		stopwatch = new AudioStopwatch(TimeSpan.FromSeconds(position), Speed);
+        if (IsPlaying)
+        {
+            stopwatch.Start();
+        }
 	}
 
 	void SetVolume(double volume, double balance)

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
@@ -13,6 +13,7 @@ partial class AudioRecorder : IAudioRecorder
 	AudioRecord? audioRecord;
 	string? audioFilePath;
 
+	const int wavHeaderLength = 44;
 	int bufferSize;
 	int sampleRate;
 	readonly AudioRecorderOptions options;
@@ -145,7 +146,7 @@ partial class AudioRecorder : IAudioRecorder
 		if (audioRecord is not null && outputStream is not null)
 		{
 			var header = GetWaveFileHeader(0, 0, sampleRate, channels, bitDepth);
-			outputStream.Write(header, 0, 44);
+			outputStream.Write(header, 0, wavHeaderLength);
 
 			while (audioRecord.RecordingState == RecordState.Recording)
 			{
@@ -173,7 +174,7 @@ partial class AudioRecorder : IAudioRecorder
 				var header = GetWaveFileHeader(totalAudioLength, totalDataLength, sampleRate, channels, bitDepth);
 
 				randomAccessFile.Seek(0);
-				randomAccessFile.Write(header, 0, 44);
+				randomAccessFile.Write(header, 0, wavHeaderLength);
 
 				randomAccessFile.Close();
 			}
@@ -191,7 +192,7 @@ partial class AudioRecorder : IAudioRecorder
 		int blockAlign = (int)(channels * (bitDepth / 8));
 		long byteRate = sampleRate * blockAlign;
 
-		byte[] header = new byte[44];
+		byte[] header = new byte[wavHeaderLength];
 
 		header[0] = Convert.ToByte('R'); // RIFF/WAVE header
 		header[1] = Convert.ToByte('I'); // (byte)'I'

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs
@@ -11,7 +11,6 @@ partial class AudioRecorder : IAudioRecorder
 	public bool IsRecording => audioRecord?.RecordingState == RecordState.Recording;
 
 	AudioRecord? audioRecord;
-	string? rawFilePath;
 	string? audioFilePath;
 
 	int bufferSize;
@@ -101,20 +100,7 @@ partial class AudioRecorder : IAudioRecorder
 			throw new InvalidOperationException("'audioFilePath' is null, this really should not happen.");
 		}
 
-		CopyWaveFile(rawFilePath, audioFilePath);
-
-		try
-		{
-			// lets delete the temp file with the raw data, after we have created the WAVE file
-			if (System.IO.File.Exists(rawFilePath))
-			{
-				System.IO.File.Delete(rawFilePath);
-			}
-		}
-		catch
-		{
-			Trace.TraceWarning("delete raw wav file failed.");
-		}
+		UpdateAudioHeaderToFile();
 
 		return Task.FromResult(GetRecording());
 	}
@@ -145,13 +131,11 @@ partial class AudioRecorder : IAudioRecorder
 	{
 		var data = new byte[bufferSize];
 
-		rawFilePath = GetTempFilePath();
-
 		FileOutputStream? outputStream;
 
 		try
 		{
-			outputStream = new FileOutputStream(rawFilePath);
+			outputStream = new FileOutputStream(audioFilePath);
 		}
 		catch (Exception ex)
 		{
@@ -160,6 +144,9 @@ partial class AudioRecorder : IAudioRecorder
 
 		if (audioRecord is not null && outputStream is not null)
 		{
+			var header = GetWaveFileHeader(0, 0, sampleRate, channels, bitDepth);
+			outputStream.Write(header, 0, 44);
+
 			while (audioRecord.RecordingState == RecordState.Recording)
 			{
 				var read = audioRecord.Read(data, 0, bufferSize);
@@ -170,43 +157,40 @@ partial class AudioRecorder : IAudioRecorder
 		}
 	}
 
-	void CopyWaveFile(string? sourcePath, string destinationPath)
+	void UpdateAudioHeaderToFile()
 	{
-		long byteRate = sampleRate * bitDepth * channels / 8;
-
 		var data = new byte[bufferSize];
 
 		try
 		{
-			FileInputStream inputStream = new(sourcePath);
-			FileOutputStream outputStream = new(destinationPath);
+			RandomAccessFile randomAccessFile = new(audioFilePath, "rw");
 
-			if (inputStream?.Channel is not null)
+			if (randomAccessFile is not null)
 			{
-				var totalAudioLength = inputStream.Channel.Size();
+				var totalAudioLength = randomAccessFile.Length();
 				var totalDataLength = totalAudioLength + 36;
 
-				WriteWaveFileHeader(outputStream, totalAudioLength, totalDataLength, sampleRate, channels, byteRate);
+				var header = GetWaveFileHeader(totalAudioLength, totalDataLength, sampleRate, channels, bitDepth);
 
-				while (inputStream.Read(data) != -1)
-				{
-					outputStream.Write(data);
-				}
+				randomAccessFile.Seek(0);
+				randomAccessFile.Write(header, 0, 44);
 
-				inputStream.Close();
-				outputStream.Close();
+				randomAccessFile.Close();
 			}
 		}
 		catch (Exception ex)
 		{
 			// Trace the exception
-			Trace.WriteLine($"An error occurred while copying the wave file: {ex.Message}");
+			Trace.WriteLine($"An error occurred while updating the wave header: {ex.Message}");
 			Trace.WriteLine($"Stack Trace: {ex.StackTrace}");
 		}
 	}
 
-	static void WriteWaveFileHeader(FileOutputStream outputStream, long audioLength, long dataLength, long sampleRate, int channels, long byteRate)
+	static byte[] GetWaveFileHeader(long audioLength, long dataLength, long sampleRate, int channels, int bitDepth)
 	{
+		int blockAlign = (int)(channels * (bitDepth / 8));
+		long byteRate = sampleRate * blockAlign;
+
 		byte[] header = new byte[44];
 
 		header[0] = Convert.ToByte('R'); // RIFF/WAVE header
@@ -241,9 +225,9 @@ partial class AudioRecorder : IAudioRecorder
 		header[29] = (byte)((byteRate >> 8) & 0xff);
 		header[30] = (byte)((byteRate >> 16) & 0xff);
 		header[31] = (byte)((byteRate >> 24) & 0xff);
-		header[32] = (byte)(2 * 16 / 8); // block align
+		header[32] = (byte)(blockAlign); // block align
 		header[33] = 0;
-		header[34] = Convert.ToByte(16); // bits per sample
+		header[34] = Convert.ToByte(bitDepth); // bits per sample
 		header[35] = 0;
 		header[36] = Convert.ToByte('d');
 		header[37] = Convert.ToByte('a');
@@ -254,7 +238,7 @@ partial class AudioRecorder : IAudioRecorder
 		header[42] = (byte)((audioLength >> 16) & 0xff);
 		header[43] = (byte)((audioLength >> 24) & 0xff);
 
-		outputStream.Write(header, 0, 44);
+		return header;
 	}
 
 	static Android.Media.Encoding SharedEncodingToAndroidEncoding(Encoding type, BitDepth bitDepth, bool throwIfNotSupported)


### PR DESCRIPTION
I notice that all platforms except Android record audio in place. For example, during recording, the audio file should be saved directly to the specified path in the code.
https://github.com/jfversluis/Plugin.Maui.Audio/blob/ba47f6086fec6d7ee2a389abb502c148971ac3e2/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs#L27

However, on Android, the audio file is initially saved to a temporary path during recording and then copied to the specified path after recording stops. This process may lead to issues such as losing important audio files if the app crashes during recording. But if we save the audio file directly to the specified path during recording, we can simply repair the WAV header at that path to recover it in case the recording does not stop normally.
To fix this issue, I think we can write the WAV header before the audio data to reserve space, and then update it after recording to finalize the audio file.

Additionally, I also found some issues with creating WAV headers on the Android platform.

BlockAlign(Number of bytes per block) shoud be (NumberOfChannels* BitsPerSample / 8). The default channel is mono, so this option is incorrect by default setting.
https://github.com/jfversluis/Plugin.Maui.Audio/blob/ba47f6086fec6d7ee2a389abb502c148971ac3e2/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs#L244

Thanks to PR [#108](https://github.com/jfversluis/Plugin.Maui.Audio/pull/108), we can adjust the bit depth (number of bits per sample), so it should be variable rather than constant. If you use Pcm8bit on the current version of Plugin.Maui.Audio.Sample, it will produce incorrect results, playing as noise.
https://github.com/jfversluis/Plugin.Maui.Audio/blob/ba47f6086fec6d7ee2a389abb502c148971ac3e2/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.android.cs#L246