### PR TITLE
Enable reusage of AudioPlayer for different sources and some other improvements

### DIFF
--- a/src/Plugin.Maui.Audio/AudioManager.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioManager.shared.cs
@@ -6,7 +6,7 @@
 public class AudioManager : IAudioManager
 {
 	static IAudioManager? currentImplementation;
-	
+
 	/// <summary>
 	/// Gets the current implementation of the audio manager.
 	/// </summary>
@@ -17,6 +17,11 @@ public class AudioManager : IAudioManager
 
 	/// <inheritdoc cref="IAudioManager.DefaultRecorderOptions"/>
 	public AudioRecorderOptions DefaultRecorderOptions { get; set; } = new();
+
+	public IAudioPlayer CreatePlayer(AudioPlayerOptions? options = default)
+	{
+		return new AudioPlayer(options ?? DefaultPlayerOptions);
+	}
 
 	/// <inheritdoc cref="IAudioManager.CreatePlayer(Stream, AudioPlayerOptions)" />
 	public IAudioPlayer CreatePlayer(Stream audioStream, AudioPlayerOptions? options = default)
@@ -31,14 +36,14 @@ public class AudioManager : IAudioManager
 	{
 		ArgumentNullException.ThrowIfNull(fileName);
 
-        return new AudioPlayer(fileName, options ?? DefaultPlayerOptions);
-    }
+		return new AudioPlayer(fileName, options ?? DefaultPlayerOptions);
+	}
 
 	/// <inheritdoc cref="IAudioManager.CreateAsyncPlayer(string, AudioPlayerOptions)" />
-	public AsyncAudioPlayer CreateAsyncPlayer(Stream audioStream, AudioPlayerOptions? options = default) => new (CreatePlayer(audioStream));
+	public AsyncAudioPlayer CreateAsyncPlayer(Stream audioStream, AudioPlayerOptions? options = default) => new(CreatePlayer(audioStream));
 
 	/// <inheritdoc cref="IAudioManager.CreateAsyncPlayer(string, AudioPlayerOptions)" />
-	public AsyncAudioPlayer CreateAsyncPlayer(string fileName, AudioPlayerOptions? options = default) => new (CreatePlayer(fileName));
+	public AsyncAudioPlayer CreateAsyncPlayer(string fileName, AudioPlayerOptions? options = default) => new(CreatePlayer(fileName));
 
 	/// <inheritdoc cref="IAudioManager.CreateRecorder(AudioRecorderOptions)" />
 	public IAudioRecorder CreateRecorder(AudioRecorderOptions? options = default)

--- a/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
+++ b/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
@@ -1,0 +1,316 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Plugin.Maui.Audio;
+
+/// <summary>
+/// Represents an audio mixer managing multiple audio channels and handling spatial audio calculations.
+/// </summary>
+public class AudioMixer : IDisposable
+{
+	/// <summary>
+	/// Gets the total number of channels managed by the AudioMixer.
+	/// </summary>
+	public int ChannelCount { get; }
+
+	/// <summary>
+	/// Gets a read-only list of audio channels.
+	/// </summary>
+	public IReadOnlyList<IAudioPlayer> Channels => _channels.AsReadOnly();
+
+	readonly List<IAudioPlayer> _channels;
+	readonly IAudioManager _audioManager;
+
+	// Spatial audio variables
+	readonly float fastDecay;
+	readonly float slowDecay;
+
+	readonly float clipDist;
+	readonly float closeDist;
+	readonly float attenuator;
+
+	/// <summary>
+	/// Gets the fast decay factor.
+	/// </summary>
+	public float FastDecay => fastDecay;
+
+	/// <summary>
+	/// Gets the slow decay factor.
+	/// </summary>
+	public float SlowDecay => slowDecay;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AudioMixer"/> class with the specified number of channels.
+	/// </summary>
+	/// <param name="audioManager">The audio manager to create audio players.</param>
+	/// <param name="numberOfChannels">The number of audio channels to manage.</param>
+	public AudioMixer(IAudioManager audioManager, int numberOfChannels)
+	{
+		if (audioManager == null)
+			throw new ArgumentNullException(nameof(audioManager));
+
+		if (numberOfChannels <= 0)
+			throw new ArgumentOutOfRangeException(nameof(numberOfChannels), "Number of channels must be positive.");
+
+		_audioManager = audioManager;
+		ChannelCount = numberOfChannels;
+		_channels = new List<IAudioPlayer>(numberOfChannels);
+
+		// Initialize spatial audio variables
+		fastDecay = (float)Math.Pow(0.5, 1.0 / (35.0 / 5.0)); // ≈ 0.9037
+		slowDecay = (float)Math.Pow(0.5, 1.0 / 35.0);         // ≈ 0.9802
+
+		clipDist = 1200f;
+		closeDist = 160f;
+		attenuator = clipDist - closeDist;
+
+		// Initialize audio channels
+		for (int i = 0; i < numberOfChannels; i++)
+		{
+			var player = _audioManager.CreatePlayer();
+			_channels.Add(player);
+		}
+	}
+
+	/// <summary>
+	/// Plays the specified audio clip on the given channel.
+	/// </summary>
+	/// <param name="channelIndex">The index of the channel to play the sound on.</param>
+	/// <param name="audioClip">The audio clip to play.</param>
+	/// <param name="loop">Indicates whether the audio should loop.</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if the channel index is invalid.</exception>
+	/// <exception cref="ArgumentNullException">Thrown if the audio clip is null.</exception>
+	public void Play(int channelIndex, IAudioSource audioClip, bool loop = false)
+	{
+		ValidateChannelIndex(channelIndex);
+		if (audioClip == null)
+			throw new ArgumentNullException(nameof(audioClip));
+
+		var player = _channels[channelIndex];
+		player.Stop(); // Stop any existing playback
+		player.SetSource(audioClip.GetAudioStream());
+		player.Loop = loop;
+		player.Play();
+	}
+
+	/// <summary>
+	/// Stops playback on the specified channel.
+	/// </summary>
+	/// <param name="channelIndex">The index of the channel to stop.</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if the channel index is invalid.</exception>
+	public void Stop(int channelIndex)
+	{
+		ValidateChannelIndex(channelIndex);
+		var player = _channels[channelIndex];
+		player.Stop();
+	}
+
+	/// <summary>
+	/// Pauses playback on all channels.
+	/// </summary>
+	public void StopAll()
+	{
+		foreach (var player in _channels)
+		{
+			player.Stop();
+		}
+	}
+
+	/// <summary>
+	/// Pauses playback on all channels.
+	/// </summary>
+	public void PauseAll()
+	{
+		foreach (var player in _channels)
+		{
+			if (player.IsPlaying)
+			{
+				player.Pause();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Resumes playback on all channels from unchanged positions.
+	/// </summary>
+	public void ResumeAll()
+	{
+		foreach (var player in _channels)
+		{
+			if (!player.IsPlaying)
+			{
+				player.Play();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Starts  playback on all channels from zero.
+	/// </summary>
+	public void PlayAll()
+	{
+		foreach (var player in _channels)
+		{
+			player.Seek(0);
+			player.Play();
+		}
+	}
+
+	/// <summary>
+	/// Sets the audio source for the specified channel without playing it.
+	/// </summary>
+	/// <param name="channelIndex">The index of the channel.</param>
+	/// <param name="audioClip">The audio clip to set as the source.</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if the channel index is invalid.</exception>
+	/// <exception cref="ArgumentNullException">Thrown if the audio clip is null.</exception>
+	public void SetSource(int channelIndex, IAudioSource audioClip)
+	{
+		ValidateChannelIndex(channelIndex);
+		if (audioClip == null)
+			throw new ArgumentNullException(nameof(audioClip));
+
+		var player = _channels[channelIndex];
+		player.Stop(); // Stop any existing playback
+		player.SetSource(audioClip.GetAudioStream());
+	}
+
+	/// <summary>
+	/// Sets the stereo balance for the specified channel.
+	/// </summary>
+	/// <param name="channelIndex">The index of the channel.</param>
+	/// <param name="balance">The balance value ranging from -1 (full left) to +1 (full right).</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if the channel index is invalid.</exception>
+	public void SetBalance(int channelIndex, float balance)
+	{
+		ValidateChannelIndex(channelIndex);
+		balance = Math.Clamp(balance, -1f, 1f);
+		var player = _channels[channelIndex];
+		player.Balance = balance;
+	}
+
+	/// <summary>
+	/// Sets the volume for the specified channel.
+	/// </summary>
+	/// <param name="channelIndex">The index of the channel.</param>
+	/// <param name="volume">The volume level (typically between 0.0 and 1.0).</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if the channel index is invalid.</exception>
+	public void SetVolume(int channelIndex, float volume)
+	{
+		ValidateChannelIndex(channelIndex);
+		volume = Math.Clamp(volume, 0f, 1f);
+		var player = _channels[channelIndex];
+		player.Volume = volume;
+	}
+
+	/// <summary>
+	/// Validates that the provided channel index is within the valid range.
+	/// </summary>
+	/// <param name="channelIndex">The channel index to validate.</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if the channel index is out of range.</exception>
+	void ValidateChannelIndex(int channelIndex)
+	{
+		if (channelIndex < 0 || channelIndex >= ChannelCount)
+			throw new ArgumentOutOfRangeException(nameof(channelIndex), $"Channel index must be between 0 and {ChannelCount - 1}.");
+	}
+
+	/// <summary>
+	/// Calculates the adjusted Balance and Volume based on the 3D position relative to the listener.
+	/// </summary>
+	/// <param name="position">The 3D position vector of the sound source.</param>
+	/// <param name="baseVolume">The base volume before spatial adjustments.</param>
+	/// <param name="baseBalance">The base balance before spatial adjustments.</param>
+	/// <returns>A tuple containing the adjusted Balance and Volume.</returns>
+	public (float Balance, float Volume) PositionInSpace(Vector3 position, float baseVolume, float baseBalance)
+	{
+		// Define the forward direction vector (same as (0, 0, -1))
+		Vector3 forward = new Vector3(0, 0, -1);
+
+		// Check if the position is approximately the forward direction
+		if (Vector3.Distance(position, forward) < 0.001f)
+		{
+			// Return the original Balance and Volume unchanged
+			return (baseBalance, baseVolume);
+		}
+
+		// Extract X and Z components for horizontal positioning
+		float x = position.X;
+		float z = position.Z;
+
+		// Calculate the angle relative to the listener's forward direction
+		float angle = MathF.Atan2(x, z); // Assuming Y is up and Z is forward
+
+		// Calculate Balance based on the angle
+		float balance = MathF.Sin(angle);
+
+		// Calculate distance from listener to sound source
+		float distance = MathF.Sqrt(x * x + z * z);
+
+		// Calculate attenuation based on distance
+		float attenuation = GetDistanceDecay(distance);
+
+		// Adjust Volume based on attenuation
+		float volume = baseVolume * attenuation;
+
+		// Introduce a panning effect modifier based on distance
+		// Farther sounds have a subtler panning effect
+		float panningEffect = Math.Clamp(1f - (distance / clipDist), 0f, 1f);
+		balance *= panningEffect;
+
+		// Clamp balance to ensure it stays within [-1, 1]
+		balance = Math.Clamp(balance, -1f, 1f);
+
+		return (balance, volume);
+	}
+
+	/// <summary>
+	/// Calculates distance-based attenuation.
+	/// </summary>
+	/// <param name="dist">Distance from the listener.</param>
+	/// <returns>Attenuation factor.</returns>
+	public float GetDistanceDecay(float dist)
+	{
+		if (dist < closeDist)
+		{
+			return 1f;
+		}
+		else
+		{
+			return Math.Max((clipDist - dist) / attenuator, 0f);
+		}
+	}
+
+	public bool IsDisposed { get; protected set; }
+
+	protected virtual void Dispose(bool disposing)
+	{
+		if (IsDisposed)
+			return;
+
+		foreach (var player in _channels)
+		{
+			try
+			{
+				player.Stop();
+				player.Dispose();
+			}
+			catch
+			{
+				// Handle or log exceptions as necessary
+			}
+		}
+
+		_channels.Clear();
+		IsDisposed = true;
+	}
+
+	/// <summary>
+	/// Disposes all managed audio players.
+	/// </summary>
+	public void Dispose()
+	{
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+}
+

--- a/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
+++ b/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
@@ -176,6 +176,13 @@ public class AudioMixer : IDisposable
 		player.SetSource(audioClip.GetAudioStream());
 	}
 
+	public IAudioPlayer GetChannel(int channelIndex)
+	{
+		ValidateChannelIndex(channelIndex);
+		var player = _channels[channelIndex];
+		return player;
+	}
+
 	/// <summary>
 	/// Sets the stereo balance for the specified channel.
 	/// </summary>

--- a/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
+++ b/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
@@ -17,16 +17,16 @@ public class AudioMixer : IDisposable
 	/// <summary>
 	/// Gets a read-only list of audio channels.
 	/// </summary>
-	public IReadOnlyList<IAudioPlayer> Channels => _channels.AsReadOnly();
+	public IReadOnlyList<IAudioPlayer> Channels => channels.AsReadOnly();
 
-	readonly List<IAudioPlayer> _channels;
-	readonly IAudioManager _audioManager;
+	readonly List<IAudioPlayer> channels;
+	readonly IAudioManager audioManager;
 	readonly float fastDecay;
 	readonly float slowDecay;
 	readonly float clipDist;
 	readonly float closeDist;
 	readonly float attenuator;
-	float _mapBalance;
+	float mapBalance;
 
 	/// <summary>
 	/// Gets the fast decay factor.
@@ -51,9 +51,9 @@ public class AudioMixer : IDisposable
 		if (numberOfChannels <= 0)
 			throw new ArgumentOutOfRangeException(nameof(numberOfChannels), "Number of channels must be positive.");
 
-		_audioManager = audioManager;
+		this.audioManager = audioManager;
 		ChannelCount = numberOfChannels;
-		_channels = new List<IAudioPlayer>(numberOfChannels);
+		channels = new List<IAudioPlayer>(numberOfChannels);
 
 		// Initialize spatial audio variables
 		fastDecay = (float)Math.Pow(0.5, 1.0 / (35.0 / 5.0)); // ≈ 0.9037
@@ -65,8 +65,8 @@ public class AudioMixer : IDisposable
 
 		for (int i = 0; i < numberOfChannels; i++)
 		{
-			var player = _audioManager.CreatePlayer();
-			_channels.Add(player);
+			var player = this.audioManager.CreatePlayer();
+			channels.Add(player);
 		}
 	}
 
@@ -84,7 +84,7 @@ public class AudioMixer : IDisposable
 		if (audioClip == null)
 			throw new ArgumentNullException(nameof(audioClip));
 
-		var player = _channels[channelIndex];
+		var player = channels[channelIndex];
 		player.Stop(); 
 		player.SetSource(audioClip.GetAudioStream());
 		player.Loop = loop;
@@ -99,7 +99,7 @@ public class AudioMixer : IDisposable
 	public void Stop(int channelIndex)
 	{
 		ValidateChannelIndex(channelIndex);
-		var player = _channels[channelIndex];
+		var player = channels[channelIndex];
 		player.Stop();
 	}
 
@@ -108,7 +108,7 @@ public class AudioMixer : IDisposable
 	/// </summary>
 	public void StopAll()
 	{
-		foreach (var player in _channels)
+		foreach (var player in channels)
 		{
 			player.Stop();
 		}
@@ -119,7 +119,7 @@ public class AudioMixer : IDisposable
 	/// </summary>
 	public void PauseAll()
 	{
-		foreach (var player in _channels)
+		foreach (var player in channels)
 		{
 			if (player.IsPlaying)
 			{
@@ -133,7 +133,7 @@ public class AudioMixer : IDisposable
 	/// </summary>
 	public void ResumeAll()
 	{
-		foreach (var player in _channels)
+		foreach (var player in channels)
 		{
 			if (!player.IsPlaying)
 			{
@@ -147,7 +147,7 @@ public class AudioMixer : IDisposable
 	/// </summary>
 	public void PlayAll()
 	{
-		foreach (var player in _channels)
+		foreach (var player in channels)
 		{
 			player.Seek(0);
 			player.Play();
@@ -167,7 +167,7 @@ public class AudioMixer : IDisposable
 		if (audioClip == null)
 			throw new ArgumentNullException(nameof(audioClip));
 
-		var player = _channels[channelIndex];
+		var player = channels[channelIndex];
 		player.Stop(); 
 		player.SetSource(audioClip.GetAudioStream());
 	}
@@ -175,7 +175,7 @@ public class AudioMixer : IDisposable
 	public IAudioPlayer GetChannel(int channelIndex)
 	{
 		ValidateChannelIndex(channelIndex);
-		var player = _channels[channelIndex];
+		var player = channels[channelIndex];
 		return player;
 	}
 
@@ -187,10 +187,10 @@ public class AudioMixer : IDisposable
 	/// <exception cref="ArgumentOutOfRangeException">Thrown if the channel index is invalid.</exception>
 	public void SetBalance(int channelIndex, float balance)
 	{
-		balance *= _mapBalance;
+		balance *= mapBalance;
 		ValidateChannelIndex(channelIndex);
 		balance = Math.Clamp(balance, -1f, 1f);
-		var player = _channels[channelIndex];
+		var player = channels[channelIndex];
 		player.Balance = balance;
 	}
 
@@ -200,7 +200,7 @@ public class AudioMixer : IDisposable
 	/// <param name="value"></param>
 	public void MapBalance(float value)
 	{
-		_mapBalance = value;
+		mapBalance = value;
 	}
 
 	/// <summary>
@@ -213,7 +213,7 @@ public class AudioMixer : IDisposable
 	{
 		ValidateChannelIndex(channelIndex);
 		volume = Math.Clamp(volume, 0f, 1f);
-		var player = _channels[channelIndex];
+		var player = channels[channelIndex];
 		player.Volume = volume;
 	}
 
@@ -283,7 +283,7 @@ public class AudioMixer : IDisposable
 		if (IsDisposed)
 			return;
 
-		foreach (var player in _channels)
+		foreach (var player in channels)
 		{
 			try
 			{
@@ -296,7 +296,7 @@ public class AudioMixer : IDisposable
 			}
 		}
 
-		_channels.Clear();
+		channels.Clear();
 		IsDisposed = true;
 	}
 

--- a/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
+++ b/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
@@ -85,7 +85,7 @@ public class AudioMixer : IDisposable
 			throw new ArgumentNullException(nameof(audioClip));
 
 		var player = _channels[channelIndex];
-		player.Stop(); // Stop any existing playback
+		player.Stop(); 
 		player.SetSource(audioClip.GetAudioStream());
 		player.Loop = loop;
 		player.Play();
@@ -168,7 +168,7 @@ public class AudioMixer : IDisposable
 			throw new ArgumentNullException(nameof(audioClip));
 
 		var player = _channels[channelIndex];
-		player.Stop(); // Stop any existing playback
+		player.Stop(); 
 		player.SetSource(audioClip.GetAudioStream());
 	}
 

--- a/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
+++ b/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
@@ -21,11 +21,8 @@ public class AudioMixer : IDisposable
 
 	readonly List<IAudioPlayer> _channels;
 	readonly IAudioManager _audioManager;
-
-	// Spatial audio variables
 	readonly float fastDecay;
 	readonly float slowDecay;
-
 	readonly float clipDist;
 	readonly float closeDist;
 	readonly float attenuator;
@@ -66,7 +63,6 @@ public class AudioMixer : IDisposable
 		closeDist = 160f;
 		attenuator = clipDist - closeDist;
 
-		// Initialize audio channels
 		for (int i = 0; i < numberOfChannels; i++)
 		{
 			var player = _audioManager.CreatePlayer();
@@ -241,41 +237,23 @@ public class AudioMixer : IDisposable
 	/// <returns>A tuple containing the adjusted Balance and Volume.</returns>
 	public (float Balance, float Volume) PositionInSpace(Vector3 position, float baseVolume, float baseBalance)
 	{
-		// Define the forward direction vector (same as (0, 0, -1))
 		Vector3 forward = new Vector3(0, 0, -1);
 
-		// Check if the position is approximately the forward direction
 		if (Vector3.Distance(position, forward) < 0.001f)
 		{
-			// Return the original Balance and Volume unchanged
 			return (baseBalance, baseVolume);
 		}
 
-		// Extract X and Z components for horizontal positioning
 		float x = position.X;
 		float z = position.Z;
-
-		// Calculate the angle relative to the listener's forward direction
-		float angle = MathF.Atan2(x, z); // Assuming Y is up and Z is forward
-
-		// Calculate Balance based on the angle
+		float angle = MathF.Atan2(x, z);
 		float balance = MathF.Sin(angle);
-
-		// Calculate distance from listener to sound source
 		float distance = MathF.Sqrt(x * x + z * z);
-
-		// Calculate attenuation based on distance
 		float attenuation = GetDistanceDecay(distance);
-
-		// Adjust Volume based on attenuation
 		float volume = baseVolume * attenuation;
-
-		// Introduce a panning effect modifier based on distance
-		// Farther sounds have a subtler panning effect
 		float panningEffect = Math.Clamp(1f - (distance / clipDist), 0f, 1f);
-		balance *= panningEffect;
 
-		// Clamp balance to ensure it stays within [-1, 1]
+		balance *= panningEffect;
 		balance = Math.Clamp(balance, -1f, 1f);
 
 		return (balance, volume);
@@ -312,9 +290,9 @@ public class AudioMixer : IDisposable
 				player.Stop();
 				player.Dispose();
 			}
-			catch
+			catch(Exception e)
 			{
-				// Handle or log exceptions as necessary
+				Console.WriteLine(e);
 			}
 		}
 

--- a/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
+++ b/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
@@ -29,6 +29,7 @@ public class AudioMixer : IDisposable
 	readonly float clipDist;
 	readonly float closeDist;
 	readonly float attenuator;
+	float _mapBalance;
 
 	/// <summary>
 	/// Gets the fast decay factor.
@@ -183,10 +184,20 @@ public class AudioMixer : IDisposable
 	/// <exception cref="ArgumentOutOfRangeException">Thrown if the channel index is invalid.</exception>
 	public void SetBalance(int channelIndex, float balance)
 	{
+		balance *= _mapBalance;
 		ValidateChannelIndex(channelIndex);
 		balance = Math.Clamp(balance, -1f, 1f);
 		var player = _channels[channelIndex];
 		player.Balance = balance;
+	}
+
+	/// <summary>
+	/// Changes the stereo balance for all channels, might need when device is rotated. 1 means not change. Range -1 to +1.
+	/// </summary>
+	/// <param name="value"></param>
+	public void MapBalance(float value)
+	{
+		_mapBalance = value;
 	}
 
 	/// <summary>

--- a/src/Plugin.Maui.Audio/AudioPlayer/AsyncAudioPlayer.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AsyncAudioPlayer.shared.cs
@@ -26,10 +26,7 @@ public class AsyncAudioPlayer : IAudio
 	public AsyncAudioPlayer(IAudioPlayer audioPlayer)
 	{
 		this.audioPlayer = audioPlayer;
-		if (audioPlayer is AudioPlayer player)
-		{
-			player.Error += OnErrorInternal;
-		}
+		audioPlayer.Error += OnErrorInternal;
 	}
 
 	/// <inheritdoc cref="IAudio.Duration" />
@@ -133,10 +130,7 @@ public class AsyncAudioPlayer : IAudio
 		{
 			if (disposing)
 			{
-				if (audioPlayer is AudioPlayer player)
-				{
-					player.Error -= OnErrorInternal;
-				}
+				audioPlayer.Error -= OnErrorInternal;
 				audioPlayer.Dispose();
 			}
 

--- a/src/Plugin.Maui.Audio/AudioPlayer/AsyncAudioPlayer.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AsyncAudioPlayer.shared.cs
@@ -43,8 +43,10 @@ public class AsyncAudioPlayer : IAudio
 	public double Speed
 	{
 		get => audioPlayer.Speed;
+		set => audioPlayer.Speed = value;
 	}
 
+	[Obsolete("Use Speed setter instead")]
 	public void SetSpeed(double speed) => audioPlayer.SetSpeed(speed);
 
 	/// <inheritdoc cref="IAudio.MinimumSpeed" />
@@ -57,7 +59,8 @@ public class AsyncAudioPlayer : IAudio
 	public bool CanSetSpeed => audioPlayer.CanSetSpeed;
 
 	/// <inheritdoc cref="IAudio.IsPlaying" />
-	public bool IsPlaying => audioPlayer.IsPlaying;
+	//public bool IsPlaying => audioPlayer.IsPlaying;
+	public bool IsPlaying { get; protected set; }
 
 	/// <inheritdoc cref="IAudio.Loop" />
 	public bool Loop

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -40,8 +40,14 @@ partial class AudioPlayer : IAudioPlayer
 	/// </summary>
 	bool isPlaying = false;
 
+	[Obsolete("Use Speed setter instead")]
 	[SupportedOSPlatform("Android23.9")]
 	public void SetSpeed(double sp)
+	{
+		SetSpeedInternal(sp);
+	}
+
+	protected void SetSpeedInternal(double sp)
 	{
 		if (!OperatingSystem.IsAndroidVersionAtLeast(23))
 		{
@@ -105,15 +111,17 @@ partial class AudioPlayer : IAudioPlayer
 		finally
 		{
 			isChangingSpeed = false;
-		}		
+		}
 	}
-
-
 
 	float internalSpeed = 1.0f;
 	double speed = 1.0;
-	public double Speed => speed;
 
+	public double Speed
+	{
+		get => speed;
+		set => SetSpeedInternal(value);
+	}
 	const float minSpeed = 0;
 	const float maxSpeed = 2.5f;
 
@@ -137,12 +145,12 @@ partial class AudioPlayer : IAudioPlayer
 
 	void PrepareAudioSource()
 	{
-		if(audioBytes == null && string.IsNullOrWhiteSpace(file))
+		if (audioBytes == null && string.IsNullOrWhiteSpace(file))
 		{
 			throw new ArgumentException("audio source is not set");
 		}
 
-		if(audioBytes != null && OperatingSystem.IsAndroidVersionAtLeast(23))
+		if (audioBytes != null && OperatingSystem.IsAndroidVersionAtLeast(23))
 		{
 			stream = new MemoryStream(audioBytes);
 			var mediaSource = new StreamMediaDataSource(stream);
@@ -175,7 +183,43 @@ partial class AudioPlayer : IAudioPlayer
 
 		player.Prepare();
 	}
-	
+
+	internal AudioPlayer(AudioPlayerOptions audioPlayerOptions)
+	{
+		player = new MediaPlayer();
+		player.Completion += OnPlaybackEnded;
+	}
+
+	public void SetSource(Stream audioStream)
+	{
+		if (OperatingSystem.IsAndroidVersionAtLeast(23))
+		{
+			using var memoryStream = new MemoryStream();
+			audioStream.CopyTo(memoryStream);
+			audioBytes = memoryStream.ToArray();
+		}
+		else
+		{
+			// we always store the audio in a file in cache, as the audio stream needs to be accessed again in case the speed is changed
+			cachePath = Path.Combine(FileSystem.CacheDirectory, $"{Guid.NewGuid()}.wav");
+
+			while (File.Exists(cachePath))
+			{
+				cachePath = Path.Combine(FileSystem.CacheDirectory, $"{Guid.NewGuid()}.wav");
+			}
+
+			var fileStream = File.Create(cachePath);
+			audioStream.CopyTo(fileStream);
+			fileStream.Close();
+
+			file = cachePath;
+		}
+
+		player.Reset();
+
+		PrepareAudioSource();
+	}
+
 	internal AudioPlayer(Stream audioStream, AudioPlayerOptions audioPlayerOptions)
 	{
 		player = new MediaPlayer();
@@ -245,7 +289,7 @@ partial class AudioPlayer : IAudioPlayer
 			Seek(0);
 			stopwatch.Reset();
 		}
-		else if(CurrentPosition >= Duration)
+		else if (CurrentPosition >= Duration)
 		{
 			Seek(0);
 			stopwatch.Reset();
@@ -266,7 +310,7 @@ partial class AudioPlayer : IAudioPlayer
 
 		Seek(0);
 		stopwatch.Reset();
-		PlaybackEnded?.Invoke(this, EventArgs.Empty);
+		OnPlaybackEnded(player, EventArgs.Empty);
 	}
 
 	public void Pause()
@@ -285,10 +329,10 @@ partial class AudioPlayer : IAudioPlayer
 	{
 		player.SeekTo((int)(position * 1000D));
 		stopwatch = new AudioStopwatch(TimeSpan.FromSeconds(position), Speed);
-        if (IsPlaying)
-        {
-            stopwatch.Start();
-        }
+		if (IsPlaying)
+		{
+			stopwatch.Start();
+		}
 	}
 
 	void SetVolume(double volume, double balance)
@@ -319,6 +363,7 @@ partial class AudioPlayer : IAudioPlayer
 
 		PlaybackEnded?.Invoke(this, e);
 	}
+
 
 	protected virtual void Dispose(bool disposing)
 	{

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -258,12 +258,12 @@ partial class AudioPlayer : IAudioPlayer
 	{
 		player = new MediaPlayer();
 		player.Completion += OnPlaybackEnded;
+		player.Error += OnError;
 
 		file = fileName;
 
 		PrepareAudioSource();
 	}
-
 
 	static void DeleteFile(string path)
 	{
@@ -364,6 +364,10 @@ partial class AudioPlayer : IAudioPlayer
 		PlaybackEnded?.Invoke(this, e);
 	}
 
+	void OnError(object? sender, MediaPlayer.ErrorEventArgs e)
+	{
+		OnError(e);
+	}
 
 	protected virtual void Dispose(bool disposing)
 	{
@@ -375,6 +379,7 @@ partial class AudioPlayer : IAudioPlayer
 		if (disposing)
 		{
 			player.Completion -= OnPlaybackEnded;
+			player.Error -= OnError;
 			player.Reset();
 			player.Release();
 			player.Dispose();

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-using AudioToolbox;
-using AVFoundation;
+﻿using AVFoundation;
 using Foundation;
 
 namespace Plugin.Maui.Audio;
@@ -90,6 +88,15 @@ partial class AudioPlayer : IAudioPlayer
 
 	public void SetSource(Stream audioStream)
 	{
+
+		if (player != null)
+		{
+			player.FinishedPlaying -= OnPlayerFinishedPlaying;
+			ActiveSessionHelper.FinishSession(audioPlayerOptions);
+			Stop();
+			player.Dispose();
+		}
+
 		var data = NSData.FromStream(audioStream)
 				   ?? throw new FailedToLoadAudioException("Unable to convert audioStream to NSData.");
 		player = AVAudioPlayer.FromData(data)

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -68,9 +68,55 @@ partial class AudioPlayer : IAudioPlayer
 
 	public bool CanSeek => true;
 
+	private static byte[] GenerateSilentWav(float durationSeconds)
+	{
+		int sampleRate = 44100; // Standard CD-quality sample rate
+		int numChannels = 1; // Mono
+		int bitsPerSample = 16; // 16-bit PCM
+		int byteRate = sampleRate * numChannels * (bitsPerSample / 8);
+		int totalDataBytes = (int)(byteRate * durationSeconds);
+
+		using (MemoryStream ms = new MemoryStream())
+		using (BinaryWriter writer = new BinaryWriter(ms))
+		{
+			// RIFF header
+			writer.Write(System.Text.Encoding.ASCII.GetBytes("RIFF"));
+			writer.Write(36 + totalDataBytes); // Total file size - 8
+			writer.Write(System.Text.Encoding.ASCII.GetBytes("WAVE"));
+
+			// Format chunk
+			writer.Write(System.Text.Encoding.ASCII.GetBytes("fmt "));
+			writer.Write(16); // Subchunk size (16 for PCM)
+			writer.Write((short)1); // Audio format (1 = PCM)
+			writer.Write((short)numChannels);
+			writer.Write(sampleRate);
+			writer.Write(byteRate);
+			writer.Write((short)(numChannels * (bitsPerSample / 8))); // Block align
+			writer.Write((short)bitsPerSample);
+
+			// Data chunk
+			writer.Write(System.Text.Encoding.ASCII.GetBytes("data"));
+			writer.Write(totalDataBytes);
+
+			// Write silent PCM data (all zeroes)
+			byte[] silence = new byte[totalDataBytes];
+			writer.Write(silence);
+
+			writer.Flush();
+			return ms.ToArray();
+		}
+	}
 	internal AudioPlayer(AudioPlayerOptions audioPlayerOptions)
 	{
+		byte[] silence = GenerateSilentWav(durationSeconds: 0.1f);
+		NSData data = NSData.FromArray(silence);
+		
+		player = AVAudioPlayer.FromData(data)
+		         ?? throw new FailedToLoadAudioException("Unable to create AVAudioPlayer from data.");
+
 		this.audioPlayerOptions = audioPlayerOptions;
+
+		PreparePlayer();
 	}
 
 	public void SetSource(Stream audioStream)

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -92,6 +92,7 @@ partial class AudioPlayer : IAudioPlayer
 		if (player != null)
 		{
 			player.FinishedPlaying -= OnPlayerFinishedPlaying;
+			player.DecoderError -= OnPlayerError;
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);
 			Stop();
 			player.Dispose();
@@ -178,10 +179,17 @@ partial class AudioPlayer : IAudioPlayer
 		ActiveSessionHelper.InitializeSession(audioPlayerOptions);
 
 		player.FinishedPlaying += OnPlayerFinishedPlaying;
+		player.DecoderError += OnPlayerError;
+
 		player.EnableRate = true;
 		player.PrepareToPlay();
 
 		return true;
+	}
+
+	void OnPlayerError(object? sender, AVErrorEventArgs e)
+	{
+		OnError(e);
 	}
 
 	void OnPlayerFinishedPlaying(object? sender, AVStatusEventArgs e)

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.net.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.net.cs
@@ -2,9 +2,13 @@
 
 partial class AudioPlayer : IAudioPlayer
 {
+	public AudioPlayer(AudioPlayerOptions audioPlayerOptions) { }
+
 	public AudioPlayer(Stream audioStream, AudioPlayerOptions audioPlayerOptions) { }
 
 	public AudioPlayer(string fileName, AudioPlayerOptions audioPlayerOptions) { }
+
+	public void SetSource(Stream audioStream) { }
 
 	protected virtual void Dispose(bool disposing) { }
 
@@ -32,7 +36,7 @@ partial class AudioPlayer : IAudioPlayer
 
 	public void Seek(double position) { }
 
-	public double Speed { get; }
+	public double Speed { get; set; }
 
 	public double MinimumSpeed { get; }
 

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.shared.cs
@@ -4,12 +4,27 @@ public partial class AudioPlayer : IAudioPlayer
 {
 #pragma warning disable CS0067
 
+	/// <summary>
+	/// Something bad happened while loading media or playing.
+	/// </summary>
+	public event EventHandler? Error;
+
 	public event EventHandler? PlaybackEnded;
 
 #pragma warning restore CS0067
 	~AudioPlayer()
 	{
 		Dispose(false);
+	}
+
+
+	/// <summary>
+	/// Something bad happened while loading media or playing.
+	/// </summary>
+	/// <param name="error">Native platform error</param>
+	protected virtual void OnError(EventArgs error)
+	{
+		Error?.Invoke(this, error);
 	}
 
 	public void Dispose()

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
@@ -86,9 +86,9 @@ partial class AudioPlayer : IAudioPlayer
 		SetSpeed(1.0);
 	}
 
-	void OnError(MediaPlayer sender, MediaPlayerFailedEventArgs args)
+	void OnError(MediaPlayer sender, MediaPlayerFailedEventArgs e)
 	{
-		throw new Exception(args.ErrorMessage);
+		OnError(new MediaPlayerFailedEventArgsWrapper(e));
 	}
 
 	public void SetSource(Stream audioStream)
@@ -230,3 +230,19 @@ partial class AudioPlayer : IAudioPlayer
 		isDisposed = true;
 	}
 }
+
+public class MediaPlayerFailedEventArgsWrapper : EventArgs
+{
+	public MediaPlayerFailedEventArgs Error { get; }
+
+	public int ErrorCode { get; }
+	public string ErrorMessage { get; }
+
+	public MediaPlayerFailedEventArgsWrapper(MediaPlayerFailedEventArgs args)
+	{
+		Error = args ?? throw new ArgumentNullException(nameof(args));
+		ErrorCode = (int)args.Error;
+		ErrorMessage = args.Error.ToString();
+	}
+}
+

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
@@ -25,9 +25,19 @@ partial class AudioPlayer : IAudioPlayer
 		set => SetVolume(Volume, value);
 	}
 
-	public double Speed => player.PlaybackSession.PlaybackRate;
+	public double Speed
+	{
+		get => player.PlaybackSession.PlaybackRate;
+		set => SetSpeedInternal(value);
+	}
 
+	[Obsolete("Use Speed setter instead")]
 	public void SetSpeed(double speed)
+	{
+		SetSpeedInternal(speed);
+	}
+
+	protected void SetSpeedInternal(double speed)
 	{
 		player.PlaybackSession.PlaybackRate = Math.Clamp(speed, MinimumSpeed, MaximumSpeed);
 	}
@@ -48,37 +58,93 @@ partial class AudioPlayer : IAudioPlayer
 
 	public bool CanSeek => player.PlaybackSession.CanSeek;
 
-    public AudioPlayer(Stream audioStream, AudioPlayerOptions audioPlayerOptions)
-    {
-        player = CreatePlayer();
+	public static Windows.Storage.Streams.IRandomAccessStream ConvertToRandomAccessStream(MemoryStream memoryStream)
+	{
+		var randomAccessStream = new Windows.Storage.Streams.InMemoryRandomAccessStream();
+		using (var outputStream = randomAccessStream.GetOutputStreamAt(0))
+		{
+			using (var dataWriter = new Windows.Storage.Streams.DataWriter(outputStream))
+			{
+				dataWriter.WriteBytes(memoryStream.ToArray());
+				dataWriter.StoreAsync().AsTask().GetAwaiter().GetResult();
+			}
+		}
+		return randomAccessStream;
+	}
+
+	public AudioPlayer(AudioPlayerOptions audioPlayerOptions)
+	{
+		player = CreatePlayer();
 
 		if (player is null)
 		{
 			throw new FailedToLoadAudioException($"Failed to create {nameof(MediaPlayer)} instance. Reason unknown.");
 		}
 
-        player.Source = MediaSource.CreateFromStream(audioStream?.AsRandomAccessStream(), string.Empty);
-        player.MediaEnded += OnPlaybackEnded;
+		player.MediaFailed += OnError;
+		player.MediaEnded += OnPlaybackEnded;
 		SetSpeed(1.0);
 	}
 
-    public AudioPlayer(string fileName, AudioPlayerOptions audioPlayerOptions)
-    {
-        player = CreatePlayer();
+	void OnError(MediaPlayer sender, MediaPlayerFailedEventArgs args)
+	{
+		throw new Exception(args.ErrorMessage);
+	}
+
+	public void SetSource(Stream audioStream)
+	{
+		if (audioStream is System.IO.MemoryStream memoryStream)
+		{
+			var winStream = ConvertToRandomAccessStream(memoryStream);
+			player.Source = MediaSource.CreateFromStream(winStream, string.Empty);
+		}
+		else
+		{
+			player.Source = MediaSource.CreateFromStream(audioStream?.AsRandomAccessStream(), string.Empty);
+		}
+	}
+
+	public AudioPlayer(Stream audioStream, AudioPlayerOptions audioPlayerOptions)
+	{
+		player = CreatePlayer();
 
 		if (player is null)
 		{
 			throw new FailedToLoadAudioException($"Failed to create {nameof(MediaPlayer)} instance. Reason unknown.");
 		}
 
-        player.Source = MediaSource.CreateFromUri(new Uri("ms-appx:///Assets/" + fileName));
-        player.MediaEnded += OnPlaybackEnded;
+		if (audioStream is System.IO.MemoryStream memoryStream)
+		{
+			var winStream = ConvertToRandomAccessStream(memoryStream);
+			player.Source = MediaSource.CreateFromStream(winStream, string.Empty);
+		}
+		else
+		{
+			player.Source = MediaSource.CreateFromStream(audioStream?.AsRandomAccessStream(), string.Empty);
+		}
+
+
+		player.MediaEnded += OnPlaybackEnded;
 		SetSpeed(1.0);
 	}
 
-    void OnPlaybackEnded(MediaPlayer sender, object args)
-    {
-        PlaybackEnded?.Invoke(sender, EventArgs.Empty);
+	public AudioPlayer(string fileName, AudioPlayerOptions audioPlayerOptions)
+	{
+		player = CreatePlayer();
+
+		if (player is null)
+		{
+			throw new FailedToLoadAudioException($"Failed to create {nameof(MediaPlayer)} instance. Reason unknown.");
+		}
+
+		player.Source = MediaSource.CreateFromUri(new Uri("ms-appx:///Assets/" + fileName));
+		player.MediaEnded += OnPlaybackEnded;
+		SetSpeed(1.0);
+	}
+
+	void OnPlaybackEnded(MediaPlayer sender, object args)
+	{
+		PlaybackEnded?.Invoke(sender, EventArgs.Empty);
 	}
 
 	public void Play()
@@ -106,7 +172,7 @@ partial class AudioPlayer : IAudioPlayer
 	{
 		Pause();
 		Seek(0);
-		PlaybackEnded?.Invoke(this, EventArgs.Empty);
+		OnPlaybackEnded(player, EventArgs.Empty); //todo check for double invoke?
 	}
 
 	public void Seek(double position)
@@ -116,9 +182,16 @@ partial class AudioPlayer : IAudioPlayer
 			return;
 		}
 
-		if (player.PlaybackSession.CanSeek)
+		try
 		{
-			player.PlaybackSession.Position = TimeSpan.FromSeconds(position);
+			if (player.PlaybackSession.CanSeek)
+			{
+				player.PlaybackSession.Position = TimeSpan.FromSeconds(position);
+			}
+		}
+		catch (Exception e)
+		{
+			Console.WriteLine(e);
 		}
 	}
 
@@ -149,6 +222,7 @@ partial class AudioPlayer : IAudioPlayer
 		{
 			Stop();
 
+			player.MediaFailed -= OnError;
 			player.MediaEnded -= OnPlaybackEnded;
 			player.Dispose();
 		}

--- a/src/Plugin.Maui.Audio/AudioPlayer/IAudio.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/IAudio.cs
@@ -27,8 +27,15 @@ public interface IAudio : IDisposable
 
 	///<Summary>
 	/// Gets the playback speed where 1 is normal speed. <see cref="MinimumSpeed"/> and <see cref="MaximumSpeed"/> can be used to determine the minumum and maximum value for each platform.
-	///</Summary>
-	double Speed { get; }
+	/// Sets the playback speed where 1 is normal speed. <see cref="MinimumSpeed"/> and <see cref="MaximumSpeed"/> can be used to determine the minumum and maximum value for each platform.
+	/// </summary>
+	///<remarks>
+	/// The minimum and maximum speeds that can be set here are different per platform. Setting values ouside of these ranges will not throw an exception, it will clamp to the minimum or maximum value.
+	///<para>- Android: between 0 and 2.5. Setting the value to 0 will pause playback, playback will not be resumed when incrementing the value again.</para>
+	///<para>- iOS: between 0.5 and 2.</para>
+	///<para>- Windows: between 0 and 8. Setting the value to 0 will pause playback, playback will be resumed when incrementing the value again.</para>
+	///</remarks>
+	double Speed { get; set; }
 
 	/// <summary>
 	/// Sets the playback speed where 1 is normal speed. <see cref="MinimumSpeed"/> and <see cref="MaximumSpeed"/> can be used to determine the minumum and maximum value for each platform.
@@ -40,6 +47,7 @@ public interface IAudio : IDisposable
 	///<para>- Windows: between 0 and 8. Setting the value to 0 will pause playback, playback will be resumed when incrementing the value again.</para>
 	///</remarks>
 	/// <param name="speed">the desired speed</param>
+	[Obsolete("Use Speed setter instead")]
 	void SetSpeed(double speed);
 
 	/// <summary>

--- a/src/Plugin.Maui.Audio/AudioPlayer/IAudioPlayer.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/IAudioPlayer.cs
@@ -10,6 +10,11 @@ public interface IAudioPlayer : IAudio
 	///</Summary>
 	event EventHandler PlaybackEnded;
 
+	/// <summary>
+	/// Something bad happened while loading media or playing.
+	/// </summary>
+	event EventHandler Error;
+
 	///<Summary>
 	/// Begin playback or resume if paused.
 	///</Summary>

--- a/src/Plugin.Maui.Audio/AudioPlayer/IAudioPlayer.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/IAudioPlayer.cs
@@ -24,4 +24,10 @@ public interface IAudioPlayer : IAudio
 	/// Stop playback and set the current position to the beginning.
 	///</Summary>
 	void Stop();
+
+	/// <summary>
+	/// Change current audio source, reusing the player instance.
+	/// </summary>
+	/// <param name="audioStream"></param>
+	void SetSource(Stream audioStream);
 }

--- a/src/Plugin.Maui.Audio/IAudioManager.shared.cs
+++ b/src/Plugin.Maui.Audio/IAudioManager.shared.cs
@@ -16,6 +16,13 @@ public interface IAudioManager
 	AudioRecorderOptions DefaultRecorderOptions { get; set; }
 
 	/// <summary>
+	/// Creates a new <see cref="IAudioPlayer"/> with with an empty source.
+	/// </summary>
+	/// <param name="options"></param>
+	/// <returns></returns>
+	IAudioPlayer CreatePlayer(AudioPlayerOptions? options = default);
+
+	/// <summary>
 	/// Creates a new <see cref="IAudioPlayer"/> with the supplied <paramref name="audioStream"/> ready to play.
 	/// </summary>
 	/// <param name="audioStream">The <see cref="Stream"/> containing the audio to play.</param>

--- a/src/Plugin.Maui.Audio/RawAudioSource.cs
+++ b/src/Plugin.Maui.Audio/RawAudioSource.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.IO;
+
+namespace Plugin.Maui.Audio;
+
+/// <summary>
+/// Enumeration for supported bits per sample in PCM audio.
+/// </summary>
+public enum BitsPerSample
+{
+	Bit8 = 8,
+	Bit16 = 16
+}
+
+/// <summary>
+/// WAV audio clip created from raw PCM sound data without header.
+/// The <see cref="Bytes"/> property provides the complete WAV file with header, usable inside a player.
+/// Supports both 8-bit and 16-bit PCM audio.
+/// </summary>
+public class RawAudioSource : IAudioSource
+{
+	readonly byte[] _soundData;
+	readonly int _sampleRate;
+	readonly int _nbOfChannels;
+	readonly BitsPerSample _bitsPerSample;
+
+	byte[] _withHeader;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RawAudioSource"/> class with 8-bit samples.
+	/// </summary>
+	/// <param name="soundData">Raw PCM sound data as a span of bytes.</param>
+	/// <param name="sampleRate">Sample rate in Hz (e.g., 44100).</param>
+	/// <param name="nbOfChannels">Number of audio channels (e.g., 1 for mono, 2 for stereo).</param>
+	public RawAudioSource(ReadOnlySpan<byte> soundData, int sampleRate, int nbOfChannels = 1, BitsPerSample bitsPerSample = BitsPerSample.Bit8)
+		: this(soundData.ToArray(), sampleRate, nbOfChannels, bitsPerSample)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RawAudioSource"/> class with specified bits per sample.
+	/// </summary>
+	/// <param name="soundData">Raw PCM sound data as a byte array.</param>
+	/// <param name="sampleRate">Sample rate in Hz (e.g., 44100).</param>
+	/// <param name="nbOfChannels">Number of audio channels (e.g., 1 for mono, 2 for stereo).</param>
+	/// <param name="bitsPerSample">Bits per sample (e.g., 8 or 16).</param>
+	public RawAudioSource(byte[] soundData, int sampleRate, int nbOfChannels = 1, BitsPerSample bitsPerSample = BitsPerSample.Bit8)
+	{
+		if (soundData == null)
+			throw new ArgumentNullException(nameof(soundData));
+
+		if (sampleRate <= 0)
+			throw new ArgumentOutOfRangeException(nameof(sampleRate), "Sample rate must be positive.");
+
+		if (nbOfChannels <= 0)
+			throw new ArgumentOutOfRangeException(nameof(nbOfChannels), "Number of channels must be positive.");
+
+		if (bitsPerSample != BitsPerSample.Bit8 && bitsPerSample != BitsPerSample.Bit16)
+			throw new NotSupportedException($"Unsupported BitsPerSample: {bitsPerSample}. Only 8-bit and 16-bit are supported.");
+
+		// Validate sound data length based on bits per sample and number of channels
+		int bytesPerSample = bitsPerSample == BitsPerSample.Bit8 ? 1 : 2;
+		if (soundData.Length % (nbOfChannels * bytesPerSample) != 0)
+			throw new ArgumentException("Sound data length is not aligned with the specified number of channels and bits per sample.", nameof(soundData));
+
+		_soundData = soundData;
+		_sampleRate = sampleRate;
+		_nbOfChannels = nbOfChannels;
+		_bitsPerSample = bitsPerSample;
+	}
+
+	public Stream GetAudioStream()
+	{
+		return new MemoryStream(Bytes, false);
+	}
+
+	/// <summary>
+	/// Gets the complete WAV file data, including the header.
+	/// </summary>
+	public byte[] Bytes
+	{
+		get
+		{
+			if (_withHeader == null)
+			{
+				_withHeader = BuildWavFile();
+			}
+
+			return _withHeader;
+		}
+	}
+
+	/// <summary>
+	/// Constructs the WAV file by prepending the appropriate header to the raw PCM data.
+	/// </summary>
+	/// <returns>Byte array containing the complete WAV file.</returns>
+	byte[] BuildWavFile()
+	{
+		int dataSize = _soundData.Length;
+		int bytesPerSample = _bitsPerSample == BitsPerSample.Bit8 ? 1 : 2;
+		int byteRate = _sampleRate * _nbOfChannels * bytesPerSample;
+		short blockAlign = (short)(_nbOfChannels * bytesPerSample);
+		short audioFormat = 1; // PCM
+		short bitsPerSample = (short)_bitsPerSample;
+
+		int fileSize = dataSize + 44 - 8; // Total file size minus "RIFF" and size field itself
+
+		byte[] wavHeader = new byte[44];
+
+		// RIFF header
+		Buffer.BlockCopy(System.Text.Encoding.ASCII.GetBytes("RIFF"), 0, wavHeader, 0, 4);
+		Buffer.BlockCopy(BitConverter.GetBytes(fileSize), 0, wavHeader, 4, 4);
+		Buffer.BlockCopy(System.Text.Encoding.ASCII.GetBytes("WAVE"), 0, wavHeader, 8, 4);
+
+		// fmt subchunk
+		Buffer.BlockCopy(System.Text.Encoding.ASCII.GetBytes("fmt "), 0, wavHeader, 12, 4);
+		Buffer.BlockCopy(BitConverter.GetBytes(16), 0, wavHeader, 16, 4); // Subchunk1Size for PCM
+		Buffer.BlockCopy(BitConverter.GetBytes(audioFormat), 0, wavHeader, 20, 2);
+		Buffer.BlockCopy(BitConverter.GetBytes((short)_nbOfChannels), 0, wavHeader, 22, 2);
+		Buffer.BlockCopy(BitConverter.GetBytes(_sampleRate), 0, wavHeader, 24, 4);
+		Buffer.BlockCopy(BitConverter.GetBytes(byteRate), 0, wavHeader, 28, 4);
+		Buffer.BlockCopy(BitConverter.GetBytes(blockAlign), 0, wavHeader, 32, 2);
+		Buffer.BlockCopy(BitConverter.GetBytes(bitsPerSample), 0, wavHeader, 34, 2);
+
+		// data subchunk
+		Buffer.BlockCopy(System.Text.Encoding.ASCII.GetBytes("data"), 0, wavHeader, 36, 4);
+		Buffer.BlockCopy(BitConverter.GetBytes(dataSize), 0, wavHeader, 40, 4);
+
+		// Combine header and sound data
+		byte[] wavSoundData = new byte[wavHeader.Length + dataSize];
+		Buffer.BlockCopy(wavHeader, 0, wavSoundData, 0, wavHeader.Length);
+		Buffer.BlockCopy(_soundData, 0, wavSoundData, wavHeader.Length, dataSize);
+
+		return wavSoundData;
+	}
+}
+

--- a/src/Plugin.Maui.Audio/RawAudioSource.cs
+++ b/src/Plugin.Maui.Audio/RawAudioSource.cs
@@ -102,9 +102,7 @@ public class RawAudioSource : IAudioSource
 		short blockAlign = (short)(_nbOfChannels * bytesPerSample);
 		short audioFormat = 1; // PCM
 		short bitsPerSample = (short)_bitsPerSample;
-
 		int fileSize = dataSize + 44 - 8; // Total file size minus "RIFF" and size field itself
-
 		byte[] wavHeader = new byte[44];
 
 		// RIFF header
@@ -112,9 +110,8 @@ public class RawAudioSource : IAudioSource
 		Buffer.BlockCopy(BitConverter.GetBytes(fileSize), 0, wavHeader, 4, 4);
 		Buffer.BlockCopy(System.Text.Encoding.ASCII.GetBytes("WAVE"), 0, wavHeader, 8, 4);
 
-		// fmt subchunk
 		Buffer.BlockCopy(System.Text.Encoding.ASCII.GetBytes("fmt "), 0, wavHeader, 12, 4);
-		Buffer.BlockCopy(BitConverter.GetBytes(16), 0, wavHeader, 16, 4); // Subchunk1Size for PCM
+		Buffer.BlockCopy(BitConverter.GetBytes(16), 0, wavHeader, 16, 4);
 		Buffer.BlockCopy(BitConverter.GetBytes(audioFormat), 0, wavHeader, 20, 2);
 		Buffer.BlockCopy(BitConverter.GetBytes((short)_nbOfChannels), 0, wavHeader, 22, 2);
 		Buffer.BlockCopy(BitConverter.GetBytes(_sampleRate), 0, wavHeader, 24, 4);
@@ -122,11 +119,9 @@ public class RawAudioSource : IAudioSource
 		Buffer.BlockCopy(BitConverter.GetBytes(blockAlign), 0, wavHeader, 32, 2);
 		Buffer.BlockCopy(BitConverter.GetBytes(bitsPerSample), 0, wavHeader, 34, 2);
 
-		// data subchunk
 		Buffer.BlockCopy(System.Text.Encoding.ASCII.GetBytes("data"), 0, wavHeader, 36, 4);
 		Buffer.BlockCopy(BitConverter.GetBytes(dataSize), 0, wavHeader, 40, 4);
 
-		// Combine header and sound data
 		byte[] wavSoundData = new byte[wavHeader.Length + dataSize];
 		Buffer.BlockCopy(wavHeader, 0, wavSoundData, 0, wavHeader.Length);
 		Buffer.BlockCopy(_soundData, 0, wavSoundData, wavHeader.Length, dataSize);


### PR DESCRIPTION
This PR is mainly for discussion.

When was trying to make DOOM play multi-channel sound have hit the fact that once created AudioPlayer cannot change its source. Recreating a new player for every new sound to be played seemed like a move less performant than reusing existing audio players, each of them acting as a separate "sound channel" for the game.

We changed this:

* Can now create an empty AudioPlayer without any source
* Can change source of an existing AudioPlayer

Among that:
* Added new IAudioSource `RawAudioSource` to be able to use raw audio samples.
This one takes an audio sample and adds a file header to it, for native player to be able to consume.

* Added AudioMixer to complete the studio of AudioPlayer and AudioRecorder.
A multi-channel sound deck, to be able to play sounds on each channel, while changing sounds on channels, changing volume, panning of every different channel while playing the whole. A base prototype of a control to be improved and enhanced further.

The use of all of the above is demonstrated here: https://github.com/taublast/Doom.Mobile

