### PR TITLE
Recording stream option with eventhandler for LinearPCM (old)

### DIFF
--- a/samples/Plugin.Maui.Audio.Sample/Pages/AudioRecorderPage.xaml
+++ b/samples/Plugin.Maui.Audio.Sample/Pages/AudioRecorderPage.xaml
@@ -17,6 +17,10 @@
 							 VerticalOptions="Center">
 
 			<Picker Title="Select Sample Rate"
+			        ItemsSource="{Binding CaptureModes}"
+			        SelectedItem="{Binding SelectedCaptureMode, Mode=TwoWay}" />
+
+			<Picker Title="Select Sample Rate"
 					ItemsSource="{Binding SampleRates}"
 					SelectedItem="{Binding SelectedSampleRate, Mode=TwoWay}" />
 

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.macios.cs
@@ -50,20 +50,20 @@ partial class AudioRecorder : IAudioRecorder
 		recorder = null;
 
 
-		if (options.CaptureMode == CaptureMode.Bundling)
+		if (audioRecorderOptions.CaptureMode == CaptureMode.Bundling)
 		{
 			var url = NSUrl.FromFilename(filePath);
 			destinationFilePath = filePath;
 
-			NSObject[] objects = new NSObject[]
-			{
+			NSObject[] objects =
+			[
 				NSNumber.FromInt32 (audioRecorderOptions.SampleRate), //Sample Rate
 				NSNumber.FromInt32 ((int)SharedEncodingToiOSEncoding(audioRecorderOptions.Encoding, audioRecorderOptions.ThrowIfNotSupported)),
 				NSNumber.FromInt32 ((int)audioRecorderOptions.Channels), //Channels
 				NSNumber.FromInt32 ((int)audioRecorderOptions.BitDepth), //PCMBitDepth
 				NSNumber.FromBoolean (false), //IsBigEndianKey
 				NSNumber.FromBoolean (false) //IsFloatKey
-			};
+			];
 
 			var settings = NSDictionary.FromObjectsAndKeys(objects, keys);
 
@@ -78,18 +78,18 @@ partial class AudioRecorder : IAudioRecorder
 		}
 		else
 		{
-			if (options.Encoding != Encoding.Wav)
+			if (audioRecorderOptions.Encoding != Encoding.Wav)
 			{
 				throw new NotSupportedException(
-					$"Encoding '{options.Encoding}' is not supported with '{options.CaptureMode}' mode");
+					$"Encoding '{audioRecorderOptions.Encoding}' is not supported with '{audioRecorderOptions.CaptureMode}' mode");
 			}
 
 			if (audioStream == null)
 			{
 				audioStream = new AudioStream(
-					options.SampleRate,
-					(int)options.Channels,
-					(int)options.BitDepth);
+					audioRecorderOptions.SampleRate,
+					(int)audioRecorderOptions.Channels,
+					(int)audioRecorderOptions.BitDepth);
 
 				audioStream.OnBroadcast += (sender, bytes) =>
 				{
@@ -112,7 +112,7 @@ partial class AudioRecorder : IAudioRecorder
 		{
 			throw new InvalidOperationException("The recorder is not recording, call StartAsync first.");
 		}
-
+		
 		if (audioRecorderOptions.CaptureMode == CaptureMode.Bundling
 		    && destinationFilePath is null)
 		{
@@ -142,15 +142,15 @@ partial class AudioRecorder : IAudioRecorder
 		return audioSource;
 	}
 
-	static readonly NSObject[] keys = new NSObject[]
-	{
+	static readonly NSObject[] keys =
+	[
 		AVAudioSettings.AVSampleRateKey,
 		AVAudioSettings.AVFormatIDKey,
 		AVAudioSettings.AVNumberOfChannelsKey,
 		AVAudioSettings.AVLinearPCMBitDepthKey,
 		AVAudioSettings.AVLinearPCMIsBigEndianKey,
 		AVAudioSettings.AVLinearPCMIsFloatKey
-	};
+	];
 	
 	void Recorder_FinishedRecording(object? sender, AVStatusEventArgs e)
 	{

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.net.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.net.cs
@@ -15,4 +15,6 @@ partial class AudioRecorder : IAudioRecorder
 	public Task StartAsync(string filePath, AudioRecorderOptions? options = null) => Task.CompletedTask;
 
 	public Task<IAudioSource> StopAsync() => Task.FromResult<IAudioSource>(new EmptyAudioSource());
+
+	public event EventHandler<AudioStreamEventArgs>? AudioStreamCaptured;
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorderOptions.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorderOptions.shared.cs
@@ -37,4 +37,10 @@ public partial class AudioRecorderOptions : BaseOptions
 	/// Gets or sets whether the functionality will throw an exception if the configured recording options are not supported.
 	/// </summary>
 	public bool ThrowIfNotSupported { get; set; } = false;
+	
+	/// <summary>
+	/// Mode when captured audio is broadcasted 
+	/// </summary>
+	public CaptureMode CaptureMode { get; set; } = CaptureMode.Bundling;
+
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioStream.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioStream.macios.cs
@@ -1,0 +1,180 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+using AudioToolbox;
+
+namespace Plugin.Maui.Audio;
+
+class AudioStream
+{
+	//
+	// inspired source https://github.com/NateRickard/Plugin.AudioRecorder/blob/master/Plugin.AudioRecorder.iOS/AudioStream.cs
+	//
+
+	const int countAudioBuffers = 3;
+	const int maxBufferSize = 0x50000; // 320 KB
+	const float targetMeasurementTime = 100F; // milliseconds
+
+	InputAudioQueue? audioQueue;
+
+	public AudioStream(int sampleRate, int channelCount, int bitsPerSample)
+	{
+		SampleRate = sampleRate;
+		ChannelCount = channelCount;
+		BitsPerSample = bitsPerSample;
+	}
+
+	public event EventHandler<byte[]> OnBroadcast;
+	public event EventHandler<bool> OnActiveChanged;
+	public event EventHandler<Exception> OnException;
+
+	public int SampleRate { get; private set; }
+	public int ChannelCount { get; private set; }
+	public int BitsPerSample { get; private set; }
+
+	public bool Active => audioQueue?.IsRunning ?? false;
+
+	public Task Start()
+	{
+		try
+		{
+			if (!Active)
+			{
+				InitAudioQueue();
+
+				BufferOperation(() => audioQueue.Start(),
+					() => OnActiveChanged?.Invoke(this, true),
+					status => throw new Exception($"audioQueue.Start() returned non-OK status: {status}"));
+			}
+
+			return Task.FromResult(true);
+		}
+		catch (Exception ex)
+		{
+			Debug.WriteLine("Error in AudioStream.Start(): {0}", ex.Message);
+
+			Stop();
+			throw;
+		}
+	}
+
+	public Task Stop()
+	{
+		if (audioQueue == null)
+		{
+			return Task.CompletedTask;
+		}
+
+		audioQueue.InputCompleted -= QueueInputCompleted;
+
+		if (audioQueue.IsRunning)
+		{
+			BufferOperation(() => audioQueue.Stop(true),
+				() => OnActiveChanged?.Invoke(this, false),
+				status => Debug.WriteLine("AudioStream.Stop() :: audioQueue.Stop returned non OK result: {0}", status));
+		}
+
+		audioQueue.Dispose();
+		audioQueue = null;
+
+		return Task.CompletedTask;
+	}
+
+	void InitAudioQueue()
+	{
+		var audioFormat = AudioStreamBasicDescription.CreateLinearPCM(SampleRate, (uint)ChannelCount, (uint)BitsPerSample);
+
+		audioQueue = new InputAudioQueue(audioFormat);
+		audioQueue.InputCompleted += QueueInputCompleted;
+
+		// calculate our buffer size and make sure it's not too big
+		var bufferByteSize = (int)(targetMeasurementTime / 1000F /*ms to sec*/ * SampleRate * audioFormat.BytesPerPacket);
+		bufferByteSize = bufferByteSize < maxBufferSize ? bufferByteSize : maxBufferSize;
+
+		for (var index = 0; index < countAudioBuffers; index++)
+		{
+			var bufferPtr = IntPtr.Zero;
+
+			BufferOperation(() => audioQueue.AllocateBuffer(bufferByteSize, out bufferPtr), () =>
+			{
+				BufferOperation(() => audioQueue.EnqueueBuffer(bufferPtr, bufferByteSize, null), () => Debug.WriteLine("AudioQueue buffer enqueued :: {0} of {1}", index + 1, countAudioBuffers));
+			});
+		}
+	}
+
+	/// <summary>
+	/// Wrapper function to run success/failure callbacks from an operation that returns an AudioQueueStatus.
+	/// </summary>
+	/// <param name="bufferFunction">The function that returns AudioQueueStatus.</param>
+	/// <param name="successAction">The Action to run if the result is AudioQueueStatus.Ok.</param>
+	/// <param name="failAction">The Action to run if the result is anything other than AudioQueueStatus.Ok.</param>
+	void BufferOperation(Func<AudioQueueStatus> bufferFunction, Action? successAction = null, Action<AudioQueueStatus?>? failAction = null)
+	{
+		AudioQueueStatus? status = null;
+		try
+		{
+			status = bufferFunction();
+		}
+		catch
+		{
+			// ignore
+		}
+
+		if (status is AudioQueueStatus.Ok)
+		{
+			successAction?.Invoke();
+		}
+		else
+		{
+			if (failAction != null)
+			{
+				failAction(status);
+			}
+			else
+			{
+				throw new Exception($"AudioStream buffer error :: buffer operation returned non - Ok status:: {status}");
+			}
+		}
+	}
+
+	/// <summary>
+	/// Handles iOS audio buffer queue completed message.
+	/// </summary>
+	/// <param name='sender'>Sender object</param>
+	/// <param name='e'>Input completed parameters.</param>
+	void QueueInputCompleted(object? sender, InputCompletedEventArgs e)
+	{
+		try
+		{
+			if (!Active)
+			{
+				return;
+			}
+
+			if (e.Buffer.AudioDataByteSize <= 0)
+			{
+				return;
+			}
+
+			var audioBytes = new byte[e.Buffer.AudioDataByteSize];
+			Marshal.Copy(e.Buffer.AudioData, audioBytes, 0, (int)e.Buffer.AudioDataByteSize);
+
+			OnBroadcast?.Invoke(this, audioBytes);
+
+			// check if active again, because the auto stop logic may stop the audio queue from within this handler!
+			if (Active)
+			{
+				BufferOperation(() => audioQueue.EnqueueBuffer(e.IntPtrBuffer, null), null, status =>
+				{
+					Debug.WriteLine("AudioStream.QueueInputCompleted() :: audioQueue.EnqueueBuffer returned non-Ok status :: {0}", status);
+					OnException?.Invoke(this, new Exception($"audioQueue.EnqueueBuffer returned non-Ok status :: {status}"));
+				});
+			}
+		}
+		catch (Exception ex)
+		{
+			Debug.WriteLine("AudioStream.QueueInputCompleted() :: Error: {0}", ex.Message);
+
+			OnException?.Invoke(this, new Exception($"AudioStream.QueueInputCompleted() :: Error: {ex.Message}"));
+		}
+	}
+}

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioStream.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioStream.macios.cs
@@ -23,13 +23,13 @@ class AudioStream
 		BitsPerSample = bitsPerSample;
 	}
 
-	public event EventHandler<byte[]> OnBroadcast;
-	public event EventHandler<bool> OnActiveChanged;
-	public event EventHandler<Exception> OnException;
+	public event EventHandler<byte[]>? OnBroadcast;
+	public event EventHandler<bool>? OnActiveChanged;
+	public event EventHandler<Exception>? OnException;
 
-	public int SampleRate { get; private set; }
-	public int ChannelCount { get; private set; }
-	public int BitsPerSample { get; private set; }
+	public int SampleRate { get; }
+	public int ChannelCount { get; }
+	public int BitsPerSample { get; }
 
 	public bool Active => audioQueue?.IsRunning ?? false;
 
@@ -107,7 +107,7 @@ class AudioStream
 	/// <param name="bufferFunction">The function that returns AudioQueueStatus.</param>
 	/// <param name="successAction">The Action to run if the result is AudioQueueStatus.Ok.</param>
 	/// <param name="failAction">The Action to run if the result is anything other than AudioQueueStatus.Ok.</param>
-	void BufferOperation(Func<AudioQueueStatus> bufferFunction, Action? successAction = null, Action<AudioQueueStatus?>? failAction = null)
+	static void BufferOperation(Func<AudioQueueStatus> bufferFunction, Action? successAction = null, Action<AudioQueueStatus?>? failAction = null)
 	{
 		AudioQueueStatus? status = null;
 		try

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioStream.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioStream.windows.cs
@@ -1,0 +1,243 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Windows.Media.Audio;
+using Windows.Media.Capture;
+using Windows.Media.MediaProperties;
+using Windows.Media.Render;
+using Windows.Media;
+using WinRT;
+
+namespace Plugin.Maui.Audio;
+
+class AudioStream
+{
+	//
+	// inspired source https://github.com/NateRickard/Plugin.AudioRecorder/blob/master/Plugin.AudioRecorder.UWP/AudioStream.cs
+	//
+
+	AudioGraph? audioGraph;
+	AudioFrameOutputNode? outputNode;
+
+	const int broadcastSize = 10; // we'll accumulate 10 'quantums' before broadcasting them
+	int bufferPosition;
+	byte[]? audioBytes;
+
+	public AudioStream(int sampleRate, int channelCount, int bitsPerSample)
+	{
+		SampleRate = sampleRate;
+		ChannelCount = channelCount;
+		BitsPerSample = bitsPerSample;
+	}
+
+	public event EventHandler<byte[]> OnBroadcast;
+	public event EventHandler<bool> OnActiveChanged;
+	public event EventHandler<Exception> OnException;
+
+	public int SampleRate { get; private set; }
+	public int ChannelCount { get; private set; }
+	public int BitsPerSample { get; private set; }
+
+	public bool Active { get; private set; }
+
+	async Task Init()
+	{
+		try
+		{
+			await Stop();
+
+			var pcmEncoding = AudioEncodingProperties.CreatePcm((uint)SampleRate, (uint)ChannelCount, (uint)BitsPerSample);
+			// apparently this is not _really_ used/supported here, as the audio data seems to come thru as floats (so basically MediaEncodingSubtypes.Float?)
+			pcmEncoding.Subtype = MediaEncodingSubtypes.Pcm;
+
+			var graphSettings = new AudioGraphSettings(AudioRenderCategory.Media)
+			{
+				EncodingProperties = pcmEncoding,
+				DesiredRenderDeviceAudioProcessing = AudioProcessing.Raw
+				// these do not seem to take effect on certain hardware and MSFT recommends SystemDefault when recording to a file anyway
+				//	We'll buffer audio data ourselves to improve RMS calculation across larger samples
+				//QuantumSizeSelectionMode = QuantumSizeSelectionMode.ClosestToDesired,
+				//DesiredSamplesPerQuantum = 4096
+			};
+
+			// create our audio graph... this will be a device input node feeding audio data into a frame output node
+			var graphResult = await AudioGraph.CreateAsync(graphSettings);
+
+			if (graphResult.Status == AudioGraphCreationStatus.Success)
+			{
+				audioGraph = graphResult.Graph;
+
+				// take input from whatever the default communications device is set to me on windows
+				var inputResult = await audioGraph.CreateDeviceInputNodeAsync(MediaCategory.Communications, pcmEncoding);
+
+				if (inputResult.Status == AudioDeviceNodeCreationStatus.Success)
+				{
+					// create the output node
+					outputNode = audioGraph.CreateFrameOutputNode(pcmEncoding);
+
+					// wire the input to the output
+					inputResult.DeviceInputNode.AddOutgoingConnection(outputNode);
+
+					// Attach to QuantumStarted event in order to receive synchronous updates from audio graph (to capture incoming audio)
+					audioGraph.QuantumStarted += Graph_QuantumStarted;
+					audioGraph.UnrecoverableErrorOccurred += Graph_UnrecoverableErrorOccurred;
+				}
+				else
+				{
+					throw new Exception($"audioGraph.CreateDeviceInputNodeAsync() returned non-Success status: {inputResult.Status}");
+				}
+			}
+			else
+			{
+				throw new Exception($"AudioGraph.CreateAsync() returned non-Success status: {graphResult.Status}");
+			}
+		}
+		catch
+		{
+			throw;
+		}
+	}
+
+	public async Task Start()
+	{
+		try
+		{
+			if (!Active)
+			{
+				await Init();
+
+				audioGraph.Start();
+
+				Active = true;
+				OnActiveChanged?.Invoke(this, true);
+			}
+		}
+		catch (Exception ex)
+		{
+			Debug.WriteLine("Error in AudioStream.Start(): {0}", ex.Message);
+
+			await Stop();
+			throw;
+		}
+	}
+
+	public Task Stop()
+	{
+		if (Active)
+		{
+			Active = false;
+
+			outputNode?.Stop();
+			audioGraph?.Stop();
+
+			OnActiveChanged?.Invoke(this, false);
+		}
+
+		outputNode?.Dispose();
+		outputNode = null;
+
+		if (audioGraph != null)
+		{
+			audioGraph.QuantumStarted -= Graph_QuantumStarted;
+			audioGraph.UnrecoverableErrorOccurred -= Graph_UnrecoverableErrorOccurred;
+			audioGraph.Dispose();
+			audioGraph = null;
+		}
+
+		return Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// IMemoryBuferByteAccess is used to access the underlying audioframe for read and write
+	/// </summary>
+	[ComImport]
+	[Guid("5B0D3235-4DBA-4D44-865E-8F1D0E4FD04D")]
+	[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+	unsafe interface IMemoryBufferByteAccess
+	{
+		void GetBuffer(out byte* buffer, out uint capacity);
+	}
+
+	unsafe void Graph_QuantumStarted(AudioGraph sender, object args)
+	{
+		// we'll only broadcast if we're actively monitoring audio packets
+		if (!Active || outputNode == null)
+		{
+			return;
+		}
+
+		try
+		{
+			var frame = outputNode.GetFrame();
+			if (frame.Duration?.Milliseconds == 0) 
+			{
+				return;
+			}
+
+			using var buffer = frame.LockBuffer(AudioBufferAccessMode.Read);
+			using var reference = buffer.CreateReference();
+
+			var memoryBuffer = reference.As<IMemoryBufferByteAccess>();
+			memoryBuffer.GetBuffer(out byte* dataInBytes, out uint capacityInBytes);
+
+			float* dataInFloat = (float*)dataInBytes;
+
+			if (audioBytes == null)
+			{
+				audioBytes = new byte[buffer.Length * broadcastSize / 2]; // buffer length * # of frames we want to accrue / 2 (because we're transforming float audio to Int 16)
+			}
+
+			for (int i = 0; i < capacityInBytes / sizeof(float); i++)
+			{
+				// convert the float into a double byte for 16 bit PCM
+				var shortVal = FloatToInt16(dataInFloat[i]);
+				byte[] chunkBytes = BitConverter.GetBytes(shortVal);
+
+				audioBytes[bufferPosition++] = chunkBytes[0];
+				audioBytes[bufferPosition++] = chunkBytes[1];
+			}
+
+			//  we want to wait until we accrue <broadcastSize> # of frames and then broadcast them
+			//	in practice, this will take us from 20ms chunks to 100ms chunks and result in more accurate audio level calculations
+			//	we could maybe use the audiograph latency settings to achieve similar results but this seems to work well
+			if (bufferPosition == audioBytes.Length || !Active)
+			{
+				// broadcast the audio data to any listeners
+				OnBroadcast?.Invoke(this, audioBytes);
+
+				audioBytes = null;
+				bufferPosition = 0;
+			}
+		}
+		catch (Exception ex)
+		{
+			OnException?.Invoke(this, new Exception($"AudioStream.QueueInputCompleted() :: Error: {ex.Message}"));
+		}
+	}
+
+	async void Graph_UnrecoverableErrorOccurred(AudioGraph sender, AudioGraphUnrecoverableErrorOccurredEventArgs args)
+	{
+		await Stop();
+
+		throw new Exception($"UnrecoverableErrorOccurred error: {args.Error}");
+	}
+
+	public void Flush()
+	{
+		if (audioBytes == null)
+		{
+			return;
+		}
+
+		OnBroadcast?.Invoke(this, audioBytes);
+		audioBytes = null;
+	}
+
+	static short FloatToInt16(float value)
+	{
+		float f = value * short.MaxValue;
+		if (f > short.MaxValue) f = short.MaxValue;
+		if (f < short.MinValue) f = short.MinValue;
+
+		return (short)f;
+	}
+}

--- a/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/IAudioRecorder.shared.cs
@@ -32,4 +32,9 @@ public interface IAudioRecorder
 	/// Stop recording and return the <see cref="IAudioSource"/> instance with the recording data.
 	///</Summary>
 	Task<IAudioSource> StopAsync();
+
+	/// <summary>
+	/// Streamed audio captured
+	/// </summary>
+	event EventHandler<AudioStreamEventArgs> AudioStreamCaptured;
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/Primitives/AudioStreamEventArgs.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/Primitives/AudioStreamEventArgs.cs
@@ -1,0 +1,11 @@
+﻿namespace Plugin.Maui.Audio;
+
+public class AudioStreamEventArgs
+{
+	public byte[] Data { get; private set; }
+
+	public AudioStreamEventArgs(byte[] data)
+	{
+		Data = data;
+	}
+}

--- a/src/Plugin.Maui.Audio/AudioRecorder/Primitives/CaptureMode.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/Primitives/CaptureMode.cs
@@ -1,0 +1,12 @@
+﻿namespace Plugin.Maui.Audio;
+
+/// <summary>
+/// Availability timing of captured audio
+/// Bundling: buffers data and delivers when finished
+/// Streaming: passthrough data byt eventhandler as soon as possible
+/// </summary>
+public enum CaptureMode
+{
+	Bundling,
+	Streaming
+}

--- a/src/Plugin.Maui.Audio/AudioRecorder/WaveFileHelper.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/WaveFileHelper.cs
@@ -1,0 +1,61 @@
+﻿namespace Plugin.Maui.Audio;
+
+public static class WaveFileHelper
+{
+	public const int WavHeaderLength = 44;
+
+	public static byte[] GetWaveFileHeader(long audioLength, long dataLength, long sampleRate, int channels, int bitDepth)
+	{
+		int blockAlign = (int)(channels * (bitDepth / 8));
+		long byteRate = sampleRate * blockAlign;
+
+		byte[] header = new byte[WavHeaderLength];
+
+		header[0] = Convert.ToByte('R'); // RIFF/WAVE header
+		header[1] = Convert.ToByte('I'); // (byte)'I'
+		header[2] = Convert.ToByte('F');
+		header[3] = Convert.ToByte('F');
+		header[4] = (byte)(dataLength & 0xff);
+		header[5] = (byte)((dataLength >> 8) & 0xff);
+		header[6] = (byte)((dataLength >> 16) & 0xff);
+		header[7] = (byte)((dataLength >> 24) & 0xff);
+		header[8] = Convert.ToByte('W');
+		header[9] = Convert.ToByte('A');
+		header[10] = Convert.ToByte('V');
+		header[11] = Convert.ToByte('E');
+		header[12] = Convert.ToByte('f'); // fmt chunk
+		header[13] = Convert.ToByte('m');
+		header[14] = Convert.ToByte('t');
+		header[15] = (byte)' ';
+		header[16] = 16; // 4 bytes - size of fmt chunk
+		header[17] = 0;
+		header[18] = 0;
+		header[19] = 0;
+		header[20] = 1; // format = 1
+		header[21] = 0;
+		header[22] = Convert.ToByte(channels);
+		header[23] = 0;
+		header[24] = (byte)(sampleRate & 0xff);
+		header[25] = (byte)((sampleRate >> 8) & 0xff);
+		header[26] = (byte)((sampleRate >> 16) & 0xff);
+		header[27] = (byte)((sampleRate >> 24) & 0xff);
+		header[28] = (byte)(byteRate & 0xff);
+		header[29] = (byte)((byteRate >> 8) & 0xff);
+		header[30] = (byte)((byteRate >> 16) & 0xff);
+		header[31] = (byte)((byteRate >> 24) & 0xff);
+		header[32] = (byte)(blockAlign); // block align
+		header[33] = 0;
+		header[34] = Convert.ToByte(bitDepth); // bits per sample
+		header[35] = 0;
+		header[36] = Convert.ToByte('d');
+		header[37] = Convert.ToByte('a');
+		header[38] = Convert.ToByte('t');
+		header[39] = Convert.ToByte('a');
+		header[40] = (byte)(audioLength & 0xff);
+		header[41] = (byte)((audioLength >> 8) & 0xff);
+		header[42] = (byte)((audioLength >> 16) & 0xff);
+		header[43] = (byte)((audioLength >> 24) & 0xff);
+
+		return header;
+	}
+}

--- a/src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj
+++ b/src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj
@@ -15,6 +15,8 @@
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 
+		<AllowUnsafeBlocks Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">true</AllowUnsafeBlocks>
+
 		<!-- NuGet -->
 		<Authors>bijington;jfversluis</Authors>
 		<Copyright>Copyright © bijington, jfversluis and contributors</Copyright>


### PR DESCRIPTION
Streaming option by EventHandler for Linear PCM.

Set the CaptureMode to Streaming to use the AudioCaptured eventhandler to get all audio bytes.