### PR TITLE
Add fast-Play method to AudioMixer

### DIFF
--- a/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
+++ b/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
@@ -71,6 +71,19 @@ public class AudioMixer : IDisposable
 	}
 
 	/// <summary>
+	/// Play already prepared channel
+	/// </summary>
+	/// <param name="channelIndex"></param>
+	/// <param name="loop"></param>
+	public void Play(int channelIndex, bool loop = false)
+	{
+		ValidateChannelIndex(channelIndex);
+		var player = channels[channelIndex];
+		player.Loop = loop;
+		player.Play();
+	}
+ 
+	/// <summary>
 	/// Plays the specified audio clip on the given channel.
 	/// </summary>
 	/// <param name="channelIndex">The index of the channel to play the sound on.</param>


### PR DESCRIPTION
We need a method to Play an existing channel without loading data in it, for example, if we just resume play.