### PR TITLE
Fix audio file storage path for reliability

### DIFF
--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
@@ -23,12 +23,14 @@ partial class AudioRecorder : IAudioRecorder
 
 	public async Task StartAsync(AudioRecorderOptions? options = null)
 	{
-		var localFolder = ApplicationData.Current.LocalFolder;
+		//var localFolder = ApplicationData.Current.LocalFolder throws an exception when consumed by some users
+		//See - https://github.com/jfversluis/Plugin.Maui.Audio/issues/145
+		var localFolder = FileSystem.AppDataDirectory;
 		var fileName = Path.GetRandomFileName();
+		var filePath = Path.Combine(localFolder, fileName);
+		File.Create(filePath).Dispose();
 
-		var fileOnDisk = await localFolder.CreateFileAsync(fileName);
-
-		await StartAsync(fileOnDisk.Path, options);
+		await StartAsync(filePath, options);
 	}
 
 	public async Task StartAsync(string filePath, AudioRecorderOptions? options = null)

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
@@ -23,7 +23,6 @@ partial class AudioRecorder : IAudioRecorder
 
 	public async Task StartAsync(AudioRecorderOptions? options = null)
 	{
-		//var localFolder = ApplicationData.Current.LocalFolder throws an exception when consumed by some users
 		//See - https://github.com/jfversluis/Plugin.Maui.Audio/issues/145
 		var localFolder = FileSystem.AppDataDirectory;
 		var fileName = Path.GetRandomFileName();

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorder.windows.cs
@@ -23,7 +23,6 @@ partial class AudioRecorder : IAudioRecorder
 
 	public async Task StartAsync(AudioRecorderOptions? options = null)
 	{
-		//See - https://github.com/jfversluis/Plugin.Maui.Audio/issues/145
 		var localFolder = FileSystem.AppDataDirectory;
 		var fileName = Path.GetRandomFileName();
 		var filePath = Path.Combine(localFolder, fileName);


### PR DESCRIPTION
Updated `AudioRecorder.windows.cs` to use `FileSystem.AppDataDirectory` instead of `ApplicationData.Current.LocalFolder` for storing audio files. This change addresses exceptions encountered by some users and ensures that audio files are created in the correct directory.

Fixes #145