### PR TITLE
Move stopwatch.Reset to OnPlaybackEnded on Android

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -309,7 +309,7 @@ partial class AudioPlayer : IAudioPlayer
 		}
 
 		Seek(0);
-		stopwatch.Reset();
+		
 		OnPlaybackEnded(player, EventArgs.Empty);
 	}
 
@@ -361,6 +361,7 @@ partial class AudioPlayer : IAudioPlayer
 			player.Prepare();
 		}
 
+		stopwatch.Reset();
 		PlaybackEnded?.Invoke(this, e);
 	}
 


### PR DESCRIPTION
Moves the `stopwatch.Reset()` call to the `OnPlaybackEnded` method on Android instead of in the `Stop` method.

This way the stopwatch is reset when the playback ends, and not only when the `Stop` method is called, which is the desired behavior.

Fixes #161