### PR TITLE
Add AudioContentType & AudioUsageKind for Android

### DIFF
--- a/docs/audio-player.md
+++ b/docs/audio-player.md
@@ -23,9 +23,12 @@ public class AudioPlayerViewModel
 
 ## Configure the playback options
 
-When calling `CreatePlayer` it is possible to provide an optional parameter of type `AudioPlayerOptions`, this parameter makes it possible to customize the playback settings at the platform level. **Note that currently you can only customize options for iOS and macOS**.
+When calling `CreatePlayer` it is possible to provide an optional parameter of type `AudioPlayerOptions`, this parameter makes it possible to customize the playback settings at the platform level. 
 
-The following example shows how to configure your audio to blend in with existing audio being played on device:
+> [!NOTE]
+> Currently you can only customize options for iOS, macOS and Android.
+
+The following example shows how to configure your audio to blend in with existing audio being played on device on iOS and macOS:
 
 ```csharp
 audioManager.CreatePlayer(
@@ -37,6 +40,24 @@ audioManager.CreatePlayer(
 #endif
     });
 ```
+
+For more information, please refer to the iOS documentation: https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions-swift.struct?language=objc
+
+This next example shows how to configure some of the attributes to describe your audio stream. This can, for example, influence which volume setting applies to your played audio.
+
+```csharp
+audioManager.CreatePlayer(
+    await FileSystem.OpenAppPackageFileAsync("ukelele.mp3"),
+    new AudioPlayerOptions
+    {
+#if ANDROID
+        AudioContentType = Android.Media.AudioContentType.Music,
+        AudioUsageKind = Android.Media.AudioUsageKind.Media,
+#endif
+    });
+```
+
+For more information, please refer to the Android documentation: https://developer.android.com/reference/android/media/AudioAttributes
 
 ## AudioPlayer API
 

--- a/samples/Plugin.Maui.Audio.Sample/MauiProgram.cs
+++ b/samples/Plugin.Maui.Audio.Sample/MauiProgram.cs
@@ -19,6 +19,10 @@ public static class MauiProgram
 #if IOS || MACCATALYST
 					playbackOptions.Category = AVFoundation.AVAudioSessionCategory.Playback;
 #endif
+#if ANDROID
+					playbackOptions.AudioContentType = Android.Media.AudioContentType.Music;
+					playbackOptions.AudioUsageKind = Android.Media.AudioUsageKind.Media;
+#endif
 				},
 				recordingOptions =>
 				{

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -187,6 +187,44 @@ partial class AudioPlayer : IAudioPlayer
 	internal AudioPlayer(AudioPlayerOptions audioPlayerOptions)
 	{
 		player = new MediaPlayer();
+
+		if (OperatingSystem.IsAndroidVersionAtLeast(26))
+		{
+			var audioAttributes = new AudioAttributes.Builder()?
+				.SetContentType(audioPlayerOptions.AudioContentType)?
+				.SetUsage(audioPlayerOptions.AudioUsageKind)?
+				.Build();
+
+			if (audioAttributes is not null)
+			{
+				player.SetAudioAttributes(audioAttributes);
+			}
+		}
+		else
+		{
+			Android.Media.Stream streamType = Android.Media.Stream.System;
+
+			switch (audioPlayerOptions.AudioUsageKind)
+			{
+				case AudioUsageKind.Media:
+					streamType = Android.Media.Stream.Music;
+					break;
+				case AudioUsageKind.Alarm:
+					streamType = Android.Media.Stream.Alarm;
+					break;
+				case AudioUsageKind.Notification:
+					streamType = Android.Media.Stream.Notification;
+					break;
+				case AudioUsageKind.VoiceCommunication:
+					streamType = Android.Media.Stream.VoiceCall;
+					break;
+				case AudioUsageKind.Unknown:
+					break;
+			}
+
+			player.SetAudioStreamType(streamType);
+		}
+			
 		player.Completion += OnPlaybackEnded;
 	}
 

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.android.cs
@@ -1,0 +1,31 @@
+﻿using Android.Media;
+
+namespace Plugin.Maui.Audio;
+
+partial class AudioPlayerOptions : BaseOptions
+{
+	/// <summary>
+	/// Gets or sets the audio content type for Android. Default value: <see cref="AudioContentType.Unknown"/>.
+	/// </summary>
+	/// <remarks>
+	/// See https://developer.android.com/reference/android/media/AudioAttributes for more information.
+	/// </remarks>
+	public AudioContentType AudioContentType { get; set; } = AudioContentType.Unknown;
+
+	/// <summary>
+	/// Gets or sets the audio usage kind for Android. Default value: <see cref="AudioUsageKind.Unknown"/>.
+	/// </summary>
+	/// <remarks>
+	/// See https://developer.android.com/reference/android/media/AudioAttributes for more information.
+	/// On Android API26 and below, this is used to set the audio stream type. Where the following values are used:
+	/// <list type="bullet">
+	/// <item><see cref="AudioUsageKind.Media"/> - <see cref="Android.Media.Stream.Music"/></item>
+	/// <item><see cref="AudioUsageKind.Alarm"/> - <see cref="Android.Media.Stream.Alarm"/></item>
+	/// <item><see cref="AudioUsageKind.Notification"/> - <see cref="Android.Media.Stream.Notification"/></item>
+	/// <item><see cref="AudioUsageKind.VoiceCommunication"/> - <see cref="Android.Media.Stream.VoiceCall"/></item>
+	/// <item><see cref="AudioUsageKind.Unknown"/> - <see cref="Android.Media.Stream.System"/></item>
+	/// </list>
+	/// If any other value is used, the default value of <see cref="Android.Media.Stream.System"/> is used.
+	/// </remarks>
+	public AudioUsageKind AudioUsageKind { get; set; } = AudioUsageKind.Unknown;
+}

--- a/src/Plugin.Maui.Audio/MauiAppBuilderExtensions.cs
+++ b/src/Plugin.Maui.Audio/MauiAppBuilderExtensions.cs
@@ -2,59 +2,63 @@ namespace Plugin.Maui.Audio;
 
 public static class MauiAppBuilderExtensions
 {
-    /// <summary>
-    /// Adds the <see cref="IAudioManager"/> as a singleton to the dependency injection container and provides the ability to configure
-    /// the shared options for both audio playback and recording.
-    /// </summary>
-    /// <param name="mauiAppBuilder">The <see cref="MauiAppBuilder"/> to register the package with.</param>
-    /// <param name="configurePlaybackOptions">
-    /// The mechanism to define the shared options for use with the <see cref="IAudioPlayer"/> implementations. Note this is optional.
-    /// An example of configuring the audio playback options for iOS and macOS, is as follows:
-    /// <code>
-    /// builder
-    ///     .AddAudio(
+	/// <summary>
+	/// Adds the <see cref="IAudioManager"/> as a singleton to the dependency injection container and provides the ability to configure
+	/// the shared options for both audio playback and recording.
+	/// </summary>
+	/// <param name="mauiAppBuilder">The <see cref="MauiAppBuilder"/> to register the package with.</param>
+	/// <param name="configurePlaybackOptions">
+	/// The mechanism to define the shared options for use with the <see cref="IAudioPlayer"/> implementations. Note this is optional.
+	/// An example of configuring the audio playback options for iOS/macOS and Android, is as follows:
+	/// <code>
+	/// builder
+	///     .AddAudio(
 	///			configurePlaybackOptions: playbackOptions =>
 	///			{
-    ///#if IOS || MACCATALYST
+	///#if IOS || MACCATALYST
 	///				playbackOptions.Category = AVFoundation.AVAudioSessionCategory.Playback;
 	///				playbackOptions.Mode = AVFoundation.AVAudioSessionMode.Default;
 	///				playbackOptions.CategoryOptions = AVFoundation.AVAudioSessionCategoryOptions.DefaultToSpeaker;
-    ///#endif
+	///#endif
+	///#if ANDROID
+	///				playbackOptions.AudioContentType = Android.Media.AudioContentType.Music;
+	///				playbackOptions.AudioUsageKind = Android.Media.AudioUsageKind.Media;
+	/// #endif
 	///			});
-    /// </code>
-    /// </param>
-    /// <param name="configureRecordingOptions">
-    /// The mechanism to define the shared options for use with the <see cref="IAudioRecorder"/> implementations. Note this is optional.
-    /// An example of configuring the audio playback options for iOS and macOS, is as follows:
-    /// <code>
-    /// builder
-    ///     .AddAudio(
+	/// </code>
+	/// </param>
+	/// <param name="configureRecordingOptions">
+	/// The mechanism to define the shared options for use with the <see cref="IAudioRecorder"/> implementations. Note this is optional.
+	/// An example of configuring the audio playback options for iOS and macOS, is as follows:
+	/// <code>
+	/// builder
+	///     .AddAudio(
 	///			configureRecordingOptions: recordingOptions =>
 	///			{
-    ///#if IOS || MACCATALYST
+	///#if IOS || MACCATALYST
 	///				recordingOptions.Category = AVFoundation.AVAudioSessionCategory.Record;
 	///				recordingOptions.Mode = AVFoundation.AVAudioSessionMode.Default;
 	///				recordingOptions.CategoryOptions = AVFoundation.AVAudioSessionCategoryOptions.DefaultToSpeaker;
-    ///#endif
+	///#endif
 	///			});
-    /// </code>
-    /// </param>
-    /// <returns>The <paramref name="mauiAppBuilder"/> supplied in order to allow for chaining of method calls.</returns>
-    public static MauiAppBuilder AddAudio(
-        this MauiAppBuilder mauiAppBuilder,
-        Action<AudioPlayerOptions>? configurePlaybackOptions = null,
-        Action<AudioRecorderOptions>? configureRecordingOptions = null)
-    {
-        var playbackOptions = new AudioPlayerOptions();
-        configurePlaybackOptions?.Invoke(playbackOptions);
-        AudioManager.Current.DefaultPlayerOptions = playbackOptions;
+	/// </code>
+	/// </param>
+	/// <returns>The <paramref name="mauiAppBuilder"/> supplied in order to allow for chaining of method calls.</returns>
+	public static MauiAppBuilder AddAudio(
+		this MauiAppBuilder mauiAppBuilder,
+		Action<AudioPlayerOptions>? configurePlaybackOptions = null,
+		Action<AudioRecorderOptions>? configureRecordingOptions = null)
+	{
+		var playbackOptions = new AudioPlayerOptions();
+		configurePlaybackOptions?.Invoke(playbackOptions);
+		AudioManager.Current.DefaultPlayerOptions = playbackOptions;
 
-        var recordingOptions = new AudioRecorderOptions();
-        configureRecordingOptions?.Invoke(recordingOptions);
-        AudioManager.Current.DefaultRecorderOptions = recordingOptions;
+		var recordingOptions = new AudioRecorderOptions();
+		configureRecordingOptions?.Invoke(recordingOptions);
+		AudioManager.Current.DefaultRecorderOptions = recordingOptions;
 
-        mauiAppBuilder.Services.AddSingleton(AudioManager.Current);
+		mauiAppBuilder.Services.AddSingleton(AudioManager.Current);
 
-        return mauiAppBuilder;
-    }
+		return mauiAppBuilder;
+	}
 }


### PR DESCRIPTION
Implements `AudioPlayerOptions` for Android so you can influence the `AudioContentType` and `AudioUsageKind` which influences on Android which volume can be used for the media being played, amongst other things.

Fixes #152