### PR TITLE
Add missing XML API docs

### DIFF
--- a/src/Plugin.Maui.Audio/AudioListeners/DecibelListener.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/DecibelListener.cs
@@ -9,6 +9,9 @@ public class DecibelListener : IPcmAudioListener
 	readonly object orderedAudioCacheLock = new();
 	int requiredSamplesForGivenTimespan;
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="DecibelListener"/> class with default settings.
+	/// </summary>
 	public DecibelListener()
 	{
 		Channels = ChannelType.Mono;
@@ -20,6 +23,9 @@ public class DecibelListener : IPcmAudioListener
 		Clear();
 	}
 
+	/// <summary>
+	/// Event raised when the measured decibel level changes beyond a threshold.
+	/// </summary>
 	public event EventHandler<DecibelChangedEventArgs>? DecibelChanged;
 
 	double decibel;
@@ -57,9 +63,15 @@ public class DecibelListener : IPcmAudioListener
 		}
 	}
 
+	/// <summary>
+	/// Gets or sets the bit depth used for audio processing.
+	/// </summary>
 	public BitDepth BitDepth { get; set; }
 
 	int sampleRate;
+	/// <summary>
+	/// Gets or sets the sample rate in Hz used for audio processing.
+	/// </summary>
 	public int SampleRate
 	{
 		get => sampleRate;
@@ -71,6 +83,9 @@ public class DecibelListener : IPcmAudioListener
 	}
 
 	ChannelType channels;
+	/// <summary>
+	/// Gets or sets the channel type (mono or stereo) used for audio processing.
+	/// </summary>
 	public ChannelType Channels
 	{
 		get => channels;
@@ -81,6 +96,10 @@ public class DecibelListener : IPcmAudioListener
 		}
 	}
 
+	/// <summary>
+	/// Processes ordered PCM audio data to calculate decibel levels.
+	/// </summary>
+	/// <param name="audioEventArgs">The ordered audio data to process.</param>
 	public void HandleOrderedPcmAudio(OrderedAudioEventArgs audioEventArgs)
 	{
 		double? currentDecibel = null;
@@ -113,6 +132,7 @@ public class DecibelListener : IPcmAudioListener
 		}
 	}
 
+	/// <inheritdoc/>
 	public void Clear()
 	{
 		Decibel = 0.0;

--- a/src/Plugin.Maui.Audio/AudioListeners/IPcmAudioListener.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/IPcmAudioListener.cs
@@ -1,15 +1,33 @@
 ﻿namespace Plugin.Maui.Audio.AudioListeners;
 
+/// <summary>
+/// Interface for PCM audio listeners that can process ordered PCM audio data.
+/// </summary>
 public interface IPcmAudioListener
 {
+	/// <summary>
+	/// Gets or sets the sample rate in Hz used for audio processing.
+	/// </summary>
 	int SampleRate { get; set; }
+	
+	/// <summary>
+	/// Gets or sets the channel type (mono or stereo) used for audio processing.
+	/// </summary>
 	ChannelType Channels { get; set; }
+	
+	/// <summary>
+	/// Gets or sets the bit depth used for audio processing.
+	/// </summary>
 	BitDepth BitDepth { get; set; }
 
+	/// <summary>
+	/// Processes ordered PCM audio data.
+	/// </summary>
+	/// <param name="audioEventArgs">The ordered audio data to process.</param>
 	void HandleOrderedPcmAudio(OrderedAudioEventArgs audioEventArgs);
 
 	/// <summary>
-	/// Clear all data and reset values to initial state
+	/// Clear all data and reset values to initial state.
 	/// </summary>
 	void Clear();
 }

--- a/src/Plugin.Maui.Audio/AudioListeners/PcmAudioHandler.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/PcmAudioHandler.cs
@@ -14,6 +14,12 @@ public class PcmAudioHandler
 	BitDepth bitDepth;
 	uint bytesPerSample;
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PcmAudioHandler"/> class.
+	/// </summary>
+	/// <param name="sampleRate">The sample rate in Hz used for audio processing.</param>
+	/// <param name="channels">The channel type (mono or stereo) used for audio processing.</param>
+	/// <param name="bitDepth">The bit depth used for audio processing.</param>
 	public PcmAudioHandler(int sampleRate, ChannelType channels, BitDepth bitDepth)
 	{
 		this.sampleRate = sampleRate;
@@ -23,13 +29,22 @@ public class PcmAudioHandler
 		bytesPerSample = (uint)BitDepth / 8;
 	}
 
+	/// <summary>
+	/// Gets or sets the mode that determines how audio data is processed and broadcast to listeners.
+	/// </summary>
 	public AudioHandlerOutputMode HandlerOutputMode { get; set; } = AudioHandlerOutputMode.Block;
 
 	/// <summary>
-	/// Optional audio output when not using listeners
+	/// Optional audio output event raised when audio data is converted, even when not using listeners.
 	/// </summary>
 	public event EventHandler<OrderedAudioEventArgs>? ConvertedAudio;
 
+	/// <summary>
+	/// Gets or sets the sample rate in Hz used for audio processing.
+	/// </summary>
+	/// <remarks>
+	/// When changed, the new value is propagated to all registered listeners.
+	/// </remarks>
 	public int SampleRate
 	{
 		get => sampleRate;
@@ -40,6 +55,12 @@ public class PcmAudioHandler
 		}
 	}
 
+	/// <summary>
+	/// Gets or sets the channel type (mono or stereo) used for audio processing.
+	/// </summary>
+	/// <remarks>
+	/// When changed, the new value is propagated to all registered listeners.
+	/// </remarks>
 	public ChannelType Channels
 	{
 		get => channels;
@@ -50,6 +71,12 @@ public class PcmAudioHandler
 		}
 	}
 
+	/// <summary>
+	/// Gets or sets the bit depth used for audio processing.
+	/// </summary>
+	/// <remarks>
+	/// When changed, the new value is propagated to all registered listeners.
+	/// </remarks>
 	public BitDepth BitDepth
 	{
 		get => bitDepth;
@@ -61,6 +88,13 @@ public class PcmAudioHandler
 		}
 	}
 
+	/// <summary>
+	/// Registers a listener to receive audio data events.
+	/// </summary>
+	/// <param name="listener">The audio listener to register.</param>
+	/// <remarks>
+	/// The listener's settings will be aligned with the handler's current settings.
+	/// </remarks>
 	public void Subscribe(IPcmAudioListener listener)
 	{
 		if (listeners.Contains(listener))
@@ -72,6 +106,10 @@ public class PcmAudioHandler
 		AlignListenerSettings(listener);
 	}
 
+	/// <summary>
+	/// Unregisters a listener from receiving audio data events.
+	/// </summary>
+	/// <param name="listener">The audio listener to unregister.</param>
 	public void Unsubscribe(IPcmAudioListener listener)
 	{
 		if (listeners.Contains(listener))
@@ -80,6 +118,9 @@ public class PcmAudioHandler
 		}
 	}
 
+	/// <summary>
+	/// Clears all data and resets values in all registered listeners.
+	/// </summary>
 	public void Clear()
 	{
 		foreach (var listener in listeners)
@@ -88,6 +129,10 @@ public class PcmAudioHandler
 		}
 	}
 
+	/// <summary>
+	/// Processes incoming PCM audio data and converts it for listeners.
+	/// </summary>
+	/// <param name="audio">The raw PCM audio data to process.</param>
 	public void HandlePcmAudio(byte[] audio)
 	{
 		var samples = new List<int>();
@@ -147,6 +192,11 @@ public class PcmAudioHandler
 		}
 	}
 
+	/// <summary>
+	/// Broadcasts audio data to all registered listeners and raises the ConvertedAudio event.
+	/// </summary>
+	/// <param name="littleEndian">The audio data converted to little-endian formatted integers.</param>
+	/// <param name="original">The original raw audio data bytes.</param>
 	public void BroadcastAudio(int[] littleEndian, byte[] original)
 	{
 		ConvertedAudio?.Invoke(this, new OrderedAudioEventArgs(littleEndian, original));

--- a/src/Plugin.Maui.Audio/AudioListeners/PcmAudioHelpers.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/PcmAudioHelpers.cs
@@ -1,5 +1,8 @@
 ﻿namespace Plugin.Maui.Audio.AudioListeners;
 
+/// <summary>
+/// Provides utility methods for working with PCM audio data.
+/// </summary>
 public static class PcmAudioHelpers
 {
 	/// <summary>
@@ -54,6 +57,14 @@ public static class PcmAudioHelpers
 		return root;
 	}
 	   
+	/// <summary>
+	/// Creates a standard WAV file header for PCM audio data.
+	/// </summary>
+	/// <param name="audioLength">The length of the audio data in bytes.</param>
+	/// <param name="sampleRate">The sample rate of the audio in Hz.</param>
+	/// <param name="channels">The number of audio channels.</param>
+	/// <param name="bitDepth">The bit depth of the audio data.</param>
+	/// <returns>A 44-byte WAV file header.</returns>
 	public static byte[] CreateWavFileHeader(long audioLength, long sampleRate, int channels, int bitDepth)
 	{
 		long dataLength = audioLength + 36;

--- a/src/Plugin.Maui.Audio/AudioListeners/Primitives/AudioHandlerOutputMode.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/Primitives/AudioHandlerOutputMode.cs
@@ -1,5 +1,8 @@
 ﻿namespace Plugin.Maui.Audio.AudioListeners;
 
+/// <summary>
+/// Specifies how audio data should be processed and broadcast to listeners.
+/// </summary>
 public enum AudioHandlerOutputMode
 {
 	/// <summary>

--- a/src/Plugin.Maui.Audio/AudioListeners/Primitives/DecibelChangedEventArgs.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/Primitives/DecibelChangedEventArgs.cs
@@ -1,9 +1,19 @@
 ﻿namespace Plugin.Maui.Audio.AudioListeners;
 
+/// <summary>
+/// Event arguments for when the decibel level changes.
+/// </summary>
 public class DecibelChangedEventArgs
 {
+	/// <summary>
+	/// Gets the current decibel level.
+	/// </summary>
 	public double Decibel { get; }
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="DecibelChangedEventArgs"/> class.
+	/// </summary>
+	/// <param name="decibel">The current decibel level.</param>
 	public DecibelChangedEventArgs(double decibel)
 	{
 		Decibel = decibel;

--- a/src/Plugin.Maui.Audio/AudioListeners/Primitives/IsSilentChangedEventArgs.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/Primitives/IsSilentChangedEventArgs.cs
@@ -1,9 +1,22 @@
 ﻿namespace Plugin.Maui.Audio.AudioListeners;
 
+/// <summary>
+/// Event arguments for when the silence state changes.
+/// </summary>
 public class IsSilentChangedEventArgs
 {
+	/// <summary>
+	/// Gets a value indicating whether the audio is currently silent.
+	/// </summary>
+	/// <remarks>
+	/// Returns null when the silence state is undetermined.
+	/// </remarks>
 	public bool? IsSilent { get; }
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="IsSilentChangedEventArgs"/> class.
+	/// </summary>
+	/// <param name="isSilent">The current silence state.</param>
 	public IsSilentChangedEventArgs(bool? isSilent)
 	{
 		IsSilent = isSilent;

--- a/src/Plugin.Maui.Audio/AudioListeners/Primitives/OrderedAudioEventArgs.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/Primitives/OrderedAudioEventArgs.cs
@@ -1,5 +1,8 @@
 ﻿namespace Plugin.Maui.Audio.AudioListeners;
 
+/// <summary>
+/// Event arguments containing ordered PCM audio data.
+/// </summary>
 public class OrderedAudioEventArgs
 {
 	/// <summary>
@@ -12,6 +15,11 @@ public class OrderedAudioEventArgs
 	/// </summary>
 	public byte[] OriginalAudio { get; }
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="OrderedAudioEventArgs"/> class.
+	/// </summary>
+	/// <param name="littleEndianOrderedAudio">Audio data in little-endian format as integers.</param>
+	/// <param name="originalAudio">Original raw audio data as bytes.</param>
 	public OrderedAudioEventArgs(int[] littleEndianOrderedAudio, byte[] originalAudio)
 	{
 		OrderedAudio = littleEndianOrderedAudio;

--- a/src/Plugin.Maui.Audio/AudioListeners/Primitives/RmsChangedEventArgs.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/Primitives/RmsChangedEventArgs.cs
@@ -1,9 +1,19 @@
 ﻿namespace Plugin.Maui.Audio.AudioListeners;
 
+/// <summary>
+/// Event arguments for when the RMS (Root Mean Square) value changes.
+/// </summary>
 public class RmsChangedEventArgs
 {
+	/// <summary>
+	/// Gets the current RMS (Root Mean Square) value.
+	/// </summary>
 	public double Rms { get; }
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RmsChangedEventArgs"/> class.
+	/// </summary>
+	/// <param name="rms">The current RMS value.</param>
 	public RmsChangedEventArgs(double rms)
 	{
 		Rms = rms;

--- a/src/Plugin.Maui.Audio/AudioListeners/RmsListener.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/RmsListener.cs
@@ -1,11 +1,17 @@
 ﻿namespace Plugin.Maui.Audio.AudioListeners;
 
+/// <summary>
+/// A listener that calculates the Root Mean Square (RMS) value from the incoming audio stream.
+/// </summary>
 public class RmsListener : IPcmAudioListener
 {
 	readonly List<int> orderedAudioCache = [];
 	readonly object orderedAudioCacheLock = new();
 	int requiredSamplesForGivenTimespan;
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RmsListener"/> class with default settings.
+	/// </summary>
 	public RmsListener()
 	{
 		Channels = ChannelType.Mono;
@@ -17,9 +23,15 @@ public class RmsListener : IPcmAudioListener
 		Clear();
 	}
 
+	/// <summary>
+	/// Event raised when the measured RMS value changes.
+	/// </summary>
 	public event EventHandler<RmsChangedEventArgs>? RmsChanged;
 
 	double rms;
+	/// <summary>
+	/// Gets the current RMS (Root Mean Square) value of the audio stream.
+	/// </summary>
 	public double Rms
 	{
 		get => rms;
@@ -50,9 +62,15 @@ public class RmsListener : IPcmAudioListener
 		}
 	}
 
+	/// <summary>
+	/// Gets or sets the bit depth used for audio processing.
+	/// </summary>
 	public BitDepth BitDepth { get; set; }
 
 	int sampleRate;
+	/// <summary>
+	/// Gets or sets the sample rate in Hz used for audio processing.
+	/// </summary>
 	public int SampleRate
 	{
 		get => sampleRate;
@@ -64,6 +82,9 @@ public class RmsListener : IPcmAudioListener
 	}
 
 	ChannelType channels;
+	/// <summary>
+	/// Gets or sets the channel type (mono or stereo) used for audio processing.
+	/// </summary>
 	public ChannelType Channels
 	{
 		get => channels;
@@ -74,6 +95,10 @@ public class RmsListener : IPcmAudioListener
 		}
 	}
 
+	/// <summary>
+	/// Processes ordered PCM audio data to calculate RMS values.
+	/// </summary>
+	/// <param name="audioEventArgs">The ordered audio data to process.</param>
 	public void HandleOrderedPcmAudio(OrderedAudioEventArgs audioEventArgs)
 	{
 		double? currentRms = null;
@@ -104,6 +129,9 @@ public class RmsListener : IPcmAudioListener
 		}
 	}
 
+	/// <summary>
+	/// Clears all data and resets values to their initial state.
+	/// </summary>
 	public void Clear()
 	{
 		Rms = 0.0;

--- a/src/Plugin.Maui.Audio/AudioListeners/SilenceListener.cs
+++ b/src/Plugin.Maui.Audio/AudioListeners/SilenceListener.cs
@@ -1,5 +1,8 @@
 ﻿namespace Plugin.Maui.Audio.AudioListeners;
 
+/// <summary>
+/// A listener that detects silence in an audio stream based on configurable thresholds.
+/// </summary>
 public class SilenceListener : IPcmAudioListener
 {
 	uint channelCount;
@@ -8,6 +11,9 @@ public class SilenceListener : IPcmAudioListener
 	float amplitudeSampleThreshold;
 	double ellapsedMillisecondsSinceDetectedSound;
 	
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SilenceListener"/> class with default settings.
+	/// </summary>
 	public SilenceListener()
 	{
 		Channels = ChannelType.Mono;
@@ -19,9 +25,15 @@ public class SilenceListener : IPcmAudioListener
 		Clear();
 	}
 
+	/// <summary>
+	/// Gets or sets the sample rate in Hz used for audio processing.
+	/// </summary>
 	public int SampleRate { get; set; }
 
 	ChannelType channels;
+	/// <summary>
+	/// Gets or sets the channel type (mono or stereo) used for audio processing.
+	/// </summary>
 	public ChannelType Channels
 	{
 		get => channels;
@@ -33,6 +45,9 @@ public class SilenceListener : IPcmAudioListener
 	}
 	
 	BitDepth bitDepth;
+	/// <summary>
+	/// Gets or sets the bit depth used for audio processing.
+	/// </summary>
 	public BitDepth BitDepth
 	{
 		get => bitDepth;
@@ -43,9 +58,18 @@ public class SilenceListener : IPcmAudioListener
 		}
 	}
 
+	/// <summary>
+	/// Event raised when the silence state changes.
+	/// </summary>
 	public event EventHandler<IsSilentChangedEventArgs>? IsSilentChanged;
 
 	bool? isSilent;
+	/// <summary>
+	/// Gets a value indicating whether the audio stream is currently silent.
+	/// </summary>
+	/// <remarks>
+	/// Returns null when the silence state is undetermined.
+	/// </remarks>
 	public bool? IsSilent
 	{
 		get => isSilent;
@@ -89,12 +113,19 @@ public class SilenceListener : IPcmAudioListener
 		}
 	}
 
+	/// <summary>
+	/// Clears all data and resets values to their initial state.
+	/// </summary>
 	public void Clear()
 	{
 		IsSilent = null;
 		ellapsedMillisecondsSinceDetectedSound = MinimalSilenceTimespanInMilliseconds;
 	}
 
+	/// <summary>
+	/// Processes ordered PCM audio data to detect silence.
+	/// </summary>
+	/// <param name="audioEventArgs">The ordered audio data to process.</param>
 	public void HandleOrderedPcmAudio(OrderedAudioEventArgs audioEventArgs)
 	{
 		var orderedAudioSamples = audioEventArgs.OrderedAudio;

--- a/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
+++ b/src/Plugin.Maui.Audio/AudioMixer/AudioMixer.cs
@@ -185,6 +185,12 @@ public class AudioMixer : IDisposable
 		player.SetSource(audioClip.GetAudioStream());
 	}
 
+	/// <summary>
+	/// Gets the audio player for the specified channel.
+	/// </summary>
+	/// <param name="channelIndex">The index of the channel to retrieve.</param>
+	/// <returns>The audio player associated with the specified channel.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown if the channel index is invalid.</exception>
 	public IAudioPlayer GetChannel(int channelIndex)
 	{
 		ValidateChannelIndex(channelIndex);
@@ -289,8 +295,15 @@ public class AudioMixer : IDisposable
 		}
 	}
 
+	/// <summary>
+	/// Gets a value indicating whether this instance has been disposed.
+	/// </summary>
 	public bool IsDisposed { get; protected set; }
 
+	/// <summary>
+	/// Releases the unmanaged resources used by the <see cref="AudioMixer"/> and optionally releases the managed resources.
+	/// </summary>
+	/// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
 	protected virtual void Dispose(bool disposing)
 	{
 		if (IsDisposed)

--- a/src/Plugin.Maui.Audio/AudioPlayer/AsyncAudioPlayer.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AsyncAudioPlayer.shared.cs
@@ -12,7 +12,7 @@ public class AsyncAudioPlayer : IAudio
 #pragma warning disable CS0067
 
 	/// <summary>
-	/// Something bad happened while loading media or playing.
+	/// Raised when an error occurred while loading media or playing.
 	/// </summary>
 	public event EventHandler? Error;
 
@@ -56,6 +56,11 @@ public class AsyncAudioPlayer : IAudio
 		set => audioPlayer.Speed = value;
 	}
 
+	/// <summary>
+	/// Sets the playback speed where 1 is normal speed.
+	/// </summary>
+	/// <param name="speed">The playback speed to set.</param>
+	/// <remarks>This method is obsolete. Use the <see cref="Speed"/> property setter instead.</remarks>
 	[Obsolete("Use Speed setter instead")]
 	public void SetSpeed(double speed) => audioPlayer.SetSpeed(speed);
 
@@ -124,6 +129,10 @@ public class AsyncAudioPlayer : IAudio
 		Error?.Invoke(this, error);
 	}
 
+	/// <summary>
+	/// Releases the unmanaged resources used by the <see cref="AsyncAudioPlayer"/> and optionally releases the managed resources.
+	/// </summary>
+	/// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
 	protected virtual void Dispose(bool disposing)
 	{
 		if (!isDisposed)
@@ -143,11 +152,17 @@ public class AsyncAudioPlayer : IAudio
 		OnError(e);
 	}
 
+	/// <summary>
+	/// Finalizer that ensures unmanaged resources are freed.
+	/// </summary>
 	~AsyncAudioPlayer()
 	{
 		Dispose(disposing: false);
 	}
 
+	/// <summary>
+	/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+	/// </summary>
 	public void Dispose()
 	{
 		Dispose(disposing: true);

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -3,40 +3,67 @@ using Foundation;
 
 namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Platform-specific implementation of the <see cref="IAudioPlayer"/> interface for macOS/iOS platforms.
+/// </summary>
 partial class AudioPlayer : IAudioPlayer
 {
 	AVAudioPlayer player;
 	readonly AudioPlayerOptions audioPlayerOptions;
 	bool isDisposed;
 
+	/// <summary>
+	/// Gets the current position of audio playback in seconds.
+	/// </summary>
 	public double CurrentPosition => player.CurrentTime;
 
+	/// <summary>
+	/// Gets the length of audio in seconds.
+	/// </summary>
 	public double Duration => player.Duration;
 
+	/// <summary>
+	/// Gets or sets the playback volume 0 to 1 where 0 is no-sound and 1 is full volume.
+	/// </summary>
 	public double Volume
 	{
 		get => player.Volume;
 		set => player.Volume = (float)Math.Clamp(value, 0, 1);
 	}
 
+	/// <summary>
+	/// Gets or sets the balance left/right: -1 is 100% left : 0% right, 1 is 100% right : 0% left, 0 is equal volume left/right.
+	/// </summary>
 	public double Balance
 	{
 		get => player.Pan;
 		set => player.Pan = (float)Math.Clamp(value, -1, 1);
 	}
 
+	/// <summary>
+	/// Gets or sets the playback speed where 1 is normal speed.
+	/// </summary>
 	public double Speed
 	{
 		get => player?.Rate ?? 0;
 		set => SetSpeedInternal(value);
 	}
 
+	/// <summary>
+	/// Sets the playback speed where 1 is normal speed.
+	/// </summary>
+	/// <param name="sp">The playback speed to set.</param>
+	/// <remarks>This method is obsolete. Use the <see cref="Speed"/> property setter instead.</remarks>
 	[Obsolete("Use Speed setter instead")]
 	public void SetSpeed(double sp)
 	{
 		SetSpeedInternal(sp);
 	}
 
+	/// <summary>
+	/// Internal implementation for setting the playback speed.
+	/// </summary>
+	/// <param name="sp">The requested speed value to set.</param>
 	protected void SetSpeedInternal(double sp)
 	{
 		// Rate property supports values in the range of 0.5 for half-speed playback to 2.0 for double-speed playback.
@@ -50,20 +77,38 @@ partial class AudioPlayer : IAudioPlayer
 		player.Rate = speedValue;
 	}
 
+	/// <summary>
+	/// Gets the minimum speed value that can be set for playback.
+	/// </summary>
 	public double MinimumSpeed => 0.5;
 
+	/// <summary>
+	/// Gets the maximum speed value that can be set for playback.
+	/// </summary>
 	public double MaximumSpeed => 2;
 
+	/// <summary>
+	/// Gets a value indicating whether the playback speed can be changed.
+	/// </summary>
 	public bool CanSetSpeed => true;
 
+	/// <summary>
+	/// Gets a value indicating whether the currently loaded audio file is playing.
+	/// </summary>
 	public bool IsPlaying => player.Playing;
 
+	/// <summary>
+	/// Gets or sets whether the player will continuously repeat the currently playing sound.
+	/// </summary>
 	public bool Loop
 	{
 		get => player.NumberOfLoops != 0;
 		set => player.NumberOfLoops = value ? -1 : 0;
 	}
 
+	/// <summary>
+	/// Gets a value indicating whether the position of the loaded audio file can be updated.
+	/// </summary>
 	public bool CanSeek => true;
 
 	static NSData? emptySource;
@@ -86,9 +131,13 @@ partial class AudioPlayer : IAudioPlayer
 		PreparePlayer();
 	}
 
+	/// <summary>
+	/// Sets the audio source to the specified stream.
+	/// </summary>
+	/// <param name="audioStream">The audio stream to use as the source.</param>
+	/// <exception cref="FailedToLoadAudioException">Thrown when the audio stream cannot be loaded.</exception>
 	public void SetSource(Stream audioStream)
 	{
-
 		if (player != null)
 		{
 			player.FinishedPlaying -= OnPlayerFinishedPlaying;
@@ -128,6 +177,10 @@ partial class AudioPlayer : IAudioPlayer
 		PreparePlayer();
 	}
 
+	/// <summary>
+	/// Releases the unmanaged resources used by the <see cref="AudioPlayer"/> and optionally releases the managed resources.
+	/// </summary>
+	/// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
 	protected virtual void Dispose(bool disposing)
 	{
 		if (isDisposed)
@@ -148,8 +201,14 @@ partial class AudioPlayer : IAudioPlayer
 		isDisposed = true;
 	}
 
+	/// <summary>
+	/// Pause playback if playing (does not resume).
+	/// </summary>
 	public void Pause() => player.Pause();
 
+	/// <summary>
+	/// Begin playback or resume if paused.
+	/// </summary>
 	public void Play()
 	{
 		if (player.Playing)
@@ -165,8 +224,15 @@ partial class AudioPlayer : IAudioPlayer
 		player.Play();
 	}
 
+	/// <summary>
+	/// Set the current playback position (in seconds).
+	/// </summary>
+	/// <param name="position">The position in seconds.</param>
 	public void Seek(double position) => player.CurrentTime = position;
 
+	/// <summary>
+	/// Stop playback and set the current position to the beginning.
+	/// </summary>
 	public void Stop()
 	{
 		player.Stop();

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.net.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.net.cs
@@ -1,46 +1,121 @@
 ﻿namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Platform-specific implementation of the <see cref="IAudioPlayer"/> interface for .NET.
+/// </summary>
 partial class AudioPlayer : IAudioPlayer
 {
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AudioPlayer"/> class with the specified options.
+	/// </summary>
+	/// <param name="audioPlayerOptions">Options to configure the audio player behavior.</param>
 	public AudioPlayer(AudioPlayerOptions audioPlayerOptions) { }
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AudioPlayer"/> class with the specified audio stream and options.
+	/// </summary>
+	/// <param name="audioStream">The audio stream to play.</param>
+	/// <param name="audioPlayerOptions">Options to configure the audio player behavior.</param>
 	public AudioPlayer(Stream audioStream, AudioPlayerOptions audioPlayerOptions) { }
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AudioPlayer"/> class with the specified file name and options.
+	/// </summary>
+	/// <param name="fileName">The name of the audio file to play.</param>
+	/// <param name="audioPlayerOptions">Options to configure the audio player behavior.</param>
 	public AudioPlayer(string fileName, AudioPlayerOptions audioPlayerOptions) { }
 
+	/// <summary>
+	/// Sets the audio source to the specified stream.
+	/// </summary>
+	/// <param name="audioStream">The audio stream to use as the source.</param>
 	public void SetSource(Stream audioStream) { }
 
+	/// <summary>
+	/// Releases the unmanaged resources used by the <see cref="AudioPlayer"/> and optionally releases the managed resources.
+	/// </summary>
+	/// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
 	protected virtual void Dispose(bool disposing) { }
 
+	/// <summary>
+	/// Gets the length of audio in seconds.
+	/// </summary>
 	public double Duration { get; }
 
+	/// <summary>
+	/// Gets the current position of audio playback in seconds.
+	/// </summary>
 	public double CurrentPosition { get; }
 
+	/// <summary>
+	/// Gets or sets the playback volume 0 to 1 where 0 is no-sound and 1 is full volume.
+	/// </summary>
 	public double Volume { get; set; }
 
+	/// <summary>
+	/// Gets or sets the balance left/right: -1 is 100% left : 0% right, 1 is 100% right : 0% left, 0 is equal volume left/right.
+	/// </summary>
 	public double Balance { get; set; }
 
+	/// <summary>
+	/// Gets a value indicating whether the currently loaded audio file is playing.
+	/// </summary>
 	public bool IsPlaying { get; }
 
+	/// <summary>
+	/// Gets or sets whether the player will continuously repeat the currently playing sound.
+	/// </summary>
 	public bool Loop { get; set; }
 
+	/// <summary>
+	/// Gets a value indicating whether the position of the loaded audio file can be updated.
+	/// </summary>
 	public bool CanSeek { get; }
 
+	/// <summary>
+	/// Begin playback or resume if paused.
+	/// </summary>
 	public void Play() { }
 
+	/// <summary>
+	/// Pause playback if playing (does not resume).
+	/// </summary>
 	public void Pause() { }
 
+	/// <summary>
+	/// Stop playback and set the current position to the beginning.
+	/// </summary>
 	public void Stop() { }
 
+	/// <summary>
+	/// Sets the playback speed where 1 is normal speed.
+	/// </summary>
+	/// <param name="speed">The desired speed value.</param>
 	public void SetSpeed(double speed) { }
 
+	/// <summary>
+	/// Set the current playback position (in seconds).
+	/// </summary>
+	/// <param name="position">The position in seconds.</param>
 	public void Seek(double position) { }
 
+	/// <summary>
+	/// Gets or sets the playback speed where 1 is normal speed.
+	/// </summary>
 	public double Speed { get; set; }
 
+	/// <summary>
+	/// Gets the minimum speed value that can be set for playback on this platform.
+	/// </summary>
 	public double MinimumSpeed { get; }
 
+	/// <summary>
+	/// Gets the maximum speed value that can be set for playback on this platform.
+	/// </summary>
 	public double MaximumSpeed { get; }
 
+	/// <summary>
+	/// Gets a value indicating whether the playback speed can be changed.
+	/// </summary>
 	public bool CanSetSpeed { get; }
 }

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.shared.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.shared.cs
@@ -5,13 +5,19 @@ public partial class AudioPlayer : IAudioPlayer
 #pragma warning disable CS0067
 
 	/// <summary>
-	/// Something bad happened while loading media or playing.
+	/// Raised when an error occurred while loading media or playing.
 	/// </summary>
 	public event EventHandler? Error;
 
+	/// <summary>
+	/// Raised when audio playback completes successfully.
+	/// </summary>
 	public event EventHandler? PlaybackEnded;
 
 #pragma warning restore CS0067
+	/// <summary>
+	/// Finalizer that ensures unmanaged resources are freed.
+	/// </summary>
 	~AudioPlayer()
 	{
 		Dispose(false);
@@ -27,6 +33,9 @@ public partial class AudioPlayer : IAudioPlayer
 		Error?.Invoke(this, error);
 	}
 
+	/// <summary>
+	/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+	/// </summary>
 	public void Dispose()
 	{
 		Dispose(true);

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.macios.cs
@@ -4,6 +4,9 @@ namespace Plugin.Maui.Audio;
 
 partial class AudioPlayerOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioPlayerOptions"/> class with default settings for macOS/iOS.
+    /// </summary>
     public AudioPlayerOptions()
     {
         Category = AVAudioSessionCategory.Playback;

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioStopwatch.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioStopwatch.cs
@@ -2,17 +2,31 @@
 
 namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// A specialized stopwatch that handles audio playback timing with support for speed adjustments and start offsets.
+/// </summary>
+/// <param name="startOffset">The initial time offset to start from.</param>
+/// <param name="speed">The playback speed factor.</param>
 public class AudioStopwatch(TimeSpan startOffset, double speed) : Stopwatch
 {
+	/// <summary>
+	/// Gets the initial time offset used when calculating elapsed time.
+	/// </summary>
 	public TimeSpan StartOffset { get; private set; } = startOffset;
 	readonly double currentSpeed = speed;
 
+	/// <summary>
+	/// Restarts the stopwatch and resets the start offset to zero.
+	/// </summary>
 	public new void Restart()
 	{
 		StartOffset = TimeSpan.Zero;
 		base.Restart();
 	}
 
+	/// <summary>
+	/// Gets the total elapsed milliseconds, adjusted by the speed factor and including the start offset.
+	/// </summary>
 	public new long ElapsedMilliseconds
 	{
 		get
@@ -21,6 +35,9 @@ public class AudioStopwatch(TimeSpan startOffset, double speed) : Stopwatch
 		}
 	}
 
+	/// <summary>
+	/// Gets the total elapsed ticks, adjusted by the speed factor and including the start offset.
+	/// </summary>
 	public new long ElapsedTicks
 	{
 		get

--- a/src/Plugin.Maui.Audio/AudioPlayer/IAudioPlayer.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/IAudioPlayer.cs
@@ -11,7 +11,7 @@ public interface IAudioPlayer : IAudio
 	event EventHandler PlaybackEnded;
 
 	/// <summary>
-	/// Something bad happened while loading media or playing.
+	/// Raised when an error occurred while loading media or playing.
 	/// </summary>
 	event EventHandler Error;
 

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorderOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorderOptions.macios.cs
@@ -4,6 +4,9 @@ namespace Plugin.Maui.Audio;
 
 partial class AudioRecorderOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioRecorderOptions"/> class with default settings for macOS/iOS.
+    /// </summary>
     public AudioRecorderOptions()
     {
         Category = AVAudioSessionCategory.Record;

--- a/src/Plugin.Maui.Audio/AudioRecorder/Primitives/BitDepth.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/Primitives/BitDepth.cs
@@ -1,7 +1,17 @@
 ﻿namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Specifies the bit depth for audio processing.
+/// </summary>
 public enum BitDepth
 {
+	/// <summary>
+	/// 8-bit PCM audio.
+	/// </summary>
 	Pcm8bit = 8,
+	
+	/// <summary>
+	/// 16-bit PCM audio.
+	/// </summary>
 	Pcm16bit = 16,
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/Primitives/ChannelType.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/Primitives/ChannelType.cs
@@ -1,7 +1,17 @@
 ﻿namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Specifies the channel configuration for audio processing.
+/// </summary>
 public enum ChannelType
 {
+	/// <summary>
+	/// Single channel audio.
+	/// </summary>
 	Mono = 1,
+	
+	/// <summary>
+	/// Dual channel audio.
+	/// </summary>
 	Stereo = 2,
 }

--- a/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamOptions.cs
+++ b/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamOptions.cs
@@ -1,5 +1,8 @@
 ﻿namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Options that can be configured for an audio streaming session.
+/// </summary>
 public partial class AudioStreamOptions : BaseOptions
 {
 	/// <summary>

--- a/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamOptions.macios.cs
@@ -4,6 +4,9 @@ namespace Plugin.Maui.Audio;
 
 public partial class AudioStreamOptions
 {
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AudioStreamOptions"/> class with default settings for macOS/iOS.
+	/// </summary>
 	public AudioStreamOptions()
 	{
 		Category = AVAudioSessionCategory.Record;

--- a/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamer.macios.cs
@@ -3,18 +3,37 @@ using AVFoundation;
 
 namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Platform-specific implementation of the <see cref="IAudioStreamer"/> interface for macOS/iOS platforms.
+/// </summary>
 public partial class AudioStreamer : IAudioStreamer
 {
 	AudioStream? audioStream;
 
+	/// <summary>
+	/// Gets whether the device is capable of streaming audio.
+	/// </summary>
 	public bool CanStreamAudio => AVAudioSession.SharedInstance().InputAvailable;
 
+	/// <summary>
+	/// Gets whether the streamer is currently streaming audio.
+	/// </summary>
 	public bool IsStreaming => audioStream is { Active: true };
 
+	/// <summary>
+	/// Gets the audio streaming options.
+	/// </summary>
 	public AudioStreamOptions Options { get; } = AudioManager.Current.DefaultStreamerOptions;
 
+	/// <summary>
+	/// Captured linear PCM audio (raw WAV audio)
+	/// </summary>
 	public event EventHandler<AudioStreamEventArgs>? OnAudioCaptured;
 
+	/// <summary>
+	/// Start streaming audio to <see cref="OnAudioCaptured"/>.
+	/// </summary>
+	/// <returns>A task representing the asynchronous operation.</returns>
 	public async Task StartAsync()
 	{
 		if (IsStreaming)
@@ -44,6 +63,10 @@ public partial class AudioStreamer : IAudioStreamer
 		await audioStream.Start();
 	}
 
+	/// <summary>
+	/// Stop streaming.
+	/// </summary>
+	/// <returns>A task representing the asynchronous operation.</returns>
 	public async Task StopAsync()
 	{
 		if (audioStream is not null)

--- a/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamer.net.cs
+++ b/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamer.net.cs
@@ -1,20 +1,43 @@
 ﻿namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Platform-specific implementation of the <see cref="IAudioStreamer"/> interface for .NET platforms.
+/// </summary>
 public partial class AudioStreamer : IAudioStreamer
 {
+	/// <summary>
+	/// Gets whether the device is capable of streaming audio.
+	/// </summary>
 	public bool CanStreamAudio => false;
 
+	/// <summary>
+	/// Gets whether the streamer is currently streaming audio.
+	/// </summary>
 	public bool IsStreaming => false;
 
+	/// <summary>
+	/// Gets the audio streaming options.
+	/// </summary>
 	public AudioStreamOptions Options { get; } = AudioManager.Current.DefaultStreamerOptions;
 
+	/// <summary>
+	/// Captured linear PCM audio (raw WAV audio)
+	/// </summary>
 	public event EventHandler<AudioStreamEventArgs>? OnAudioCaptured;
 
+	/// <summary>
+	/// Start streaming audio to <see cref="OnAudioCaptured"/>.
+	/// </summary>
+	/// <returns>A task representing the asynchronous operation.</returns>
 	public Task StartAsync()
 	{
 		return Task.CompletedTask;
 	}
 
+	/// <summary>
+	/// Stop streaming.
+	/// </summary>
+	/// <returns>A task representing the asynchronous operation.</returns>
 	public Task StopAsync()
 	{
 		return Task.CompletedTask;

--- a/src/Plugin.Maui.Audio/AudioStreamer/IAudioStreamer.cs
+++ b/src/Plugin.Maui.Audio/AudioStreamer/IAudioStreamer.cs
@@ -26,7 +26,6 @@ public interface IAudioStreamer
 	///<Summary>
 	/// Start streaming audio to <see cref="OnAudioCaptured"/>.
 	///</Summary>
-	///<param name="options">The audio streaming options</param>
 	Task StartAsync();
 
 	///<Summary>

--- a/src/Plugin.Maui.Audio/AudioStreamer/Primitives/AudioStreamEventArgs.cs
+++ b/src/Plugin.Maui.Audio/AudioStreamer/Primitives/AudioStreamEventArgs.cs
@@ -1,9 +1,19 @@
 ﻿namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Event arguments containing audio stream data.
+/// </summary>
 public class AudioStreamEventArgs
 {
+	/// <summary>
+	/// Gets the audio data as a byte array.
+	/// </summary>
 	public byte[] Audio { get; private set; }
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AudioStreamEventArgs"/> class.
+	/// </summary>
+	/// <param name="audio">The audio data as a byte array.</param>
 	public AudioStreamEventArgs(byte[] audio)
 	{
 		Audio = audio;

--- a/src/Plugin.Maui.Audio/BaseOptions.shared.cs
+++ b/src/Plugin.Maui.Audio/BaseOptions.shared.cs
@@ -1,5 +1,8 @@
 namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Base class for all audio operation option classes in the library.
+/// </summary>
 public abstract partial class BaseOptions
 {
 }

--- a/src/Plugin.Maui.Audio/EmptyAudioSource.cs
+++ b/src/Plugin.Maui.Audio/EmptyAudioSource.cs
@@ -1,6 +1,13 @@
 ﻿namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// An <see cref="IAudioSource"/> implementation that returns an empty audio stream.
+/// </summary>
 public class EmptyAudioSource : IAudioSource
 {
+	/// <summary>
+	/// Gets an empty audio stream.
+	/// </summary>
+	/// <returns>A null stream representing empty audio content.</returns>
 	public Stream GetAudioStream() => Stream.Null;
 }

--- a/src/Plugin.Maui.Audio/FileAudioSource.cs
+++ b/src/Plugin.Maui.Audio/FileAudioSource.cs
@@ -5,6 +5,10 @@
 /// </summary>
 public class FileAudioSource : IAudioSource
 {
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FileAudioSource"/> class.
+	/// </summary>
+	/// <param name="filePath">The path to the audio file.</param>
 	public FileAudioSource(string filePath)
 	{
 		this.filePath = filePath;
@@ -12,11 +16,19 @@ public class FileAudioSource : IAudioSource
 
 	readonly string filePath;
 
+	/// <summary>
+	/// Gets the file path of this audio source.
+	/// </summary>
+	/// <returns>The file path of the audio source.</returns>
 	public string GetFilePath()
 	{
 		return filePath;
 	}
 
+	/// <summary>
+	/// Provides a <see cref="Stream"/> to allow for the playback of the audio contents.
+	/// </summary>
+	/// <returns>A <see cref="Stream"/> with the contents of the audio file, or a null stream if the file doesn't exist.</returns>
 	public Stream GetAudioStream()
 	{
 		if (File.Exists(filePath))

--- a/src/Plugin.Maui.Audio/IAudioManager.shared.cs
+++ b/src/Plugin.Maui.Audio/IAudioManager.shared.cs
@@ -23,14 +23,15 @@ public interface IAudioManager
 	/// <summary>
 	/// Creates a new <see cref="IAudioPlayer"/> with with an empty source.
 	/// </summary>
-	/// <param name="options"></param>
-	/// <returns></returns>
+	/// <param name="options">Options to configure the audio player behavior, or null to use the default options.</param>
+	/// <returns>A new <see cref="IAudioPlayer"/> with an empty source.</returns>
 	IAudioPlayer CreatePlayer(AudioPlayerOptions? options = default);
 
 	/// <summary>
 	/// Creates a new <see cref="IAudioPlayer"/> with the supplied <paramref name="audioStream"/> ready to play.
 	/// </summary>
 	/// <param name="audioStream">The <see cref="Stream"/> containing the audio to play.</param>
+	/// <param name="options">Options to configure the audio player behavior, or null to use the default options.</param>
 	/// <returns>A new <see cref="IAudioPlayer"/> with the supplied <paramref name="audioStream"/> ready to play.</returns>
 	IAudioPlayer CreatePlayer(Stream audioStream, AudioPlayerOptions? options = default);
 
@@ -38,26 +39,26 @@ public interface IAudioManager
 	/// Creates a new <see cref="IAudioPlayer"/> with the supplied <paramref name="fileName"/> ready to play.
 	/// </summary>
 	/// <param name="fileName">The name of the file containing the audio to play.</param>
+	/// <param name="options">Options to configure the audio player behavior, or null to use the default options.</param>
 	/// <returns>A new <see cref="IAudioPlayer"/> with the supplied <paramref name="fileName"/> ready to play.</returns>
 	IAudioPlayer CreatePlayer(string fileName, AudioPlayerOptions? options = default);
 
-	/// <summary>
-	/// Creates a new <see cref="AsyncAudioPlayer"/> with the supplied <paramref name="audioStream"/> ready to play audio using async/await.
-	/// </summary>
-	/// <param name="audioStream">The <see cref="Stream"/> containing the audio to play.</param>
-	/// <returns>A new <see cref="AsyncAudioPlayer"/> with the supplied <paramref name="audioStream"/> ready to play.</returns>
+	/// <summary>Creates a new AsyncAudioPlayer with the supplied audioStream ready to play audio using async/await.</summary>
+	/// <param name="audioStream">The Stream containing the audio to play.</param>
+	/// <param name="options">Options to configure the audio player behavior, or null to use the default options.</param>
+	/// <returns>A new AsyncAudioPlayer with the supplied audioStream ready to play.</returns>
 	AsyncAudioPlayer CreateAsyncPlayer(Stream audioStream, AudioPlayerOptions? options = default);
 
-	/// <summary>
-	/// Creates a new <see cref="AsyncAudioPlayer"/> with the supplied <paramref name="fileName"/> ready to play audio using async/await.
-	/// </summary>
+	/// <summary>Creates a new AsyncAudioPlayer with the supplied fileName ready to play audio using async/await.</summary>
 	/// <param name="fileName">The name of the file containing the audio to play.</param>
-	/// <returns>A new <see cref="AsyncAudioPlayer"/> with the supplied <paramref name="fileName"/> ready to play.</returns>
+	/// <param name="options">Options to configure the audio player behavior, or null to use the default options.</param>
+	/// <returns>A new AsyncAudioPlayer with the supplied fileName ready to play.</returns>
 	AsyncAudioPlayer CreateAsyncPlayer(string fileName, AudioPlayerOptions? options = default);
 
 	/// <summary>
 	/// Creates a new <see cref="IAudioRecorder"/> ready to begin recording audio from the current device.
 	/// </summary>
+	/// <param name="options">Options to configure the audio recorder behavior, or null to use the default options.</param>
 	/// <returns>A new <see cref="IAudioRecorder"/> ready to begin recording.</returns>
 	IAudioRecorder CreateRecorder(AudioRecorderOptions? options = default);
 

--- a/src/Plugin.Maui.Audio/MauiAppBuilderExtensions.cs
+++ b/src/Plugin.Maui.Audio/MauiAppBuilderExtensions.cs
@@ -1,5 +1,8 @@
 namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Provides extension methods for registering Plugin.Maui.Audio services with the MAUI dependency injection container.
+/// </summary>
 public static class MauiAppBuilderExtensions
 {
 	/// <summary>

--- a/src/Plugin.Maui.Audio/RawAudioSource.cs
+++ b/src/Plugin.Maui.Audio/RawAudioSource.cs
@@ -8,7 +8,14 @@ namespace Plugin.Maui.Audio;
 /// </summary>
 public enum BitsPerSample
 {
+	/// <summary>
+	/// 8-bit sample depth.
+	/// </summary>
 	Bit8 = 8,
+	
+	/// <summary>
+	/// 16-bit sample depth.
+	/// </summary>
 	Bit16 = 16
 }
 
@@ -32,6 +39,7 @@ public class RawAudioSource : IAudioSource
 	/// <param name="soundData">Raw PCM sound data as a span of bytes.</param>
 	/// <param name="sampleRate">Sample rate in Hz (e.g., 44100).</param>
 	/// <param name="nbOfChannels">Number of audio channels (e.g., 1 for mono, 2 for stereo).</param>
+	/// <param name="bitsPerSample">Bits per sample (e.g., 8 or 16).</param>
 	public RawAudioSource(ReadOnlySpan<byte> soundData, int sampleRate, int nbOfChannels = 1, BitsPerSample bitsPerSample = BitsPerSample.Bit8)
 		: this(soundData.ToArray(), sampleRate, nbOfChannels, bitsPerSample)
 	{
@@ -69,6 +77,10 @@ public class RawAudioSource : IAudioSource
 		_bitsPerSample = bitsPerSample;
 	}
 
+	/// <summary>
+	/// Gets a stream providing access to the audio data with WAV header.
+	/// </summary>
+	/// <returns>A memory stream containing the complete WAV file data.</returns>
 	public Stream GetAudioStream()
 	{
 		return new MemoryStream(Bytes, false);

--- a/src/Plugin.Maui.Audio/TaskExtensions.cs
+++ b/src/Plugin.Maui.Audio/TaskExtensions.cs
@@ -1,5 +1,8 @@
 ﻿namespace Plugin.Maui.Audio;
 
+/// <summary>
+/// Provides extension methods for Task-related operations.
+/// </summary>
 public static class TaskExtensions
 {
 	/// <summary>


### PR DESCRIPTION
Adds the missing API documentation on public APIs. This was generated with the help of AI and then (mostly) reviewed by me.

Additionally, this enables raising errors when documentation is missing from here on out so we won't be adding new APIs without documentation.