### PR TITLE
Audio should not play when changing speed

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -107,6 +107,10 @@ partial class AudioPlayer : IAudioPlayer
 				stopwatch.Start();
 				player.Start();
 			}
+			else // Explicitly pause the player if it was not playing before
+			{
+				player.Pause();
+			}
 		}
 		finally
 		{


### PR DESCRIPTION
This implements the proposed code fix mentioned in the issue and prevents the audio from starting to play when the speed is changed on Android.

Fixes #148