### PR TITLE
Allow audio playback from any path on Windows

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
@@ -131,7 +131,7 @@ partial class AudioPlayer : IAudioPlayer
 			throw new FailedToLoadAudioException($"Failed to create {nameof(MediaPlayer)} instance. Reason unknown.");
 		}
 
-		player.Source = MediaSource.CreateFromUri(new Uri("ms-appx:///Assets/" + fileName));
+		player.Source = MediaSource.CreateFromUri(new Uri(fileName));
 		player.MediaEnded += OnPlaybackEnded;
 		Speed = 1.0;
 	}


### PR DESCRIPTION
I noticed that audio files only located under "Assets" can be played on Windows platforms using the following API.

https://github.com/jfversluis/Plugin.Maui.Audio/blob/931337eecb5bc3895262b035b69e82a56c5ea8ce/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.net.cs#L26
https://github.com/jfversluis/Plugin.Maui.Audio/blob/931337eecb5bc3895262b035b69e82a56c5ea8ce/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs#L134

Maybe we can use the fileName directly to play audio, enabling users to play audio from any location(Recordings saved in FileSystem.AppDataDirectory, for example).