### PR TITLE
Added option to allow for audio session management in iOS

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -202,7 +202,7 @@ partial class AudioPlayer : IAudioPlayer
 		player.Pause();
 
 		// Stop the audio session to allow other aps audio to resume while paused.
-		if (audioPlayerOptions.OnPlayAudioSession)
+		if (audioPlayerOptions.HandleAudioSessions)
 		{
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);
 		}
@@ -214,7 +214,7 @@ partial class AudioPlayer : IAudioPlayer
 	public void Play()
 	{
 		// Start the audio session if this session is only started on play
-		if (audioPlayerOptions.OnPlayAudioSession)
+		if (audioPlayerOptions.HandleAudioSessions)
 		{
 			ActiveSessionHelper.InitializeSession(audioPlayerOptions);
 		}
@@ -248,7 +248,7 @@ partial class AudioPlayer : IAudioPlayer
 		PlaybackEnded?.Invoke(this, EventArgs.Empty);
 
 		// Stop the audio session to allow other apps audio to resume while stopped.
-		if (audioPlayerOptions.OnPlayAudioSession)
+		if (audioPlayerOptions.HandleAudioSessions)
 		{
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);
 		}
@@ -256,8 +256,8 @@ partial class AudioPlayer : IAudioPlayer
 
 	bool PreparePlayer()
 	{
-		// Don't initialise the session if it will be initialised on play instead. 
-		if (audioPlayerOptions.OnPlayAudioSession == false)
+		// Don't initialize the session if it will be initialized on play instead. 
+		if (audioPlayerOptions.HandleAudioSessions == false)
 		{
 			ActiveSessionHelper.InitializeSession(audioPlayerOptions);
 		}
@@ -353,7 +353,7 @@ partial class AudioPlayer : IAudioPlayer
 	void OnPlayerFinishedPlaying(object? sender, AVStatusEventArgs e)
 	{
 		// Stop the audio session to allow other apps audio to resume when audio is finished.
-		if (audioPlayerOptions.OnPlayAudioSession)
+		if (audioPlayerOptions.HandleAudioSessions)
 		{
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);
 		}

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -247,7 +247,7 @@ partial class AudioPlayer : IAudioPlayer
 		Seek(0);
 		PlaybackEnded?.Invoke(this, EventArgs.Empty);
 
-		// Stop the audio session to allow other aps audio to resume while stopped.
+		// Stop the audio session to allow other apps audio to resume while stopped.
 		if (audioPlayerOptions.OnPlayAudioSession)
 		{
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);
@@ -352,7 +352,7 @@ partial class AudioPlayer : IAudioPlayer
 
 	void OnPlayerFinishedPlaying(object? sender, AVStatusEventArgs e)
 	{
-		// Stop the audio session to allow other aps audio to resume when audio is finished.
+		// Stop the audio session to allow other apps audio to resume when audio is finished.
 		if (audioPlayerOptions.OnPlayAudioSession)
 		{
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -197,13 +197,28 @@ partial class AudioPlayer : IAudioPlayer
 	/// <summary>
 	/// Pause playback if playing (does not resume).
 	/// </summary>
-	public void Pause() => player.Pause();
+	public void Pause()
+	{
+		player.Pause();
+
+		// Stop the audio session to allow other aps audio to resume while paused.
+		if (audioPlayerOptions.OnPlayAudioSession)
+		{
+			ActiveSessionHelper.FinishSession(audioPlayerOptions);
+		}
+	}
 
 	/// <summary>
 	/// Begin playback or resume if paused.
 	/// </summary>
 	public void Play()
 	{
+		// Start the audio session if this session is only started on play
+		if (audioPlayerOptions.OnPlayAudioSession)
+		{
+			ActiveSessionHelper.InitializeSession(audioPlayerOptions);
+		}
+
 		if (player.Playing)
 		{
 			player.Pause();
@@ -231,11 +246,21 @@ partial class AudioPlayer : IAudioPlayer
 		player.Stop();
 		Seek(0);
 		PlaybackEnded?.Invoke(this, EventArgs.Empty);
+
+		// Stop the audio session to allow other aps audio to resume while stopped.
+		if (audioPlayerOptions.OnPlayAudioSession)
+		{
+			ActiveSessionHelper.FinishSession(audioPlayerOptions);
+		}
 	}
 
 	bool PreparePlayer()
 	{
-		ActiveSessionHelper.InitializeSession(audioPlayerOptions);
+		// Don't initialise the session if it will be initialised on play instead. 
+		if (audioPlayerOptions.OnPlayAudioSession == false)
+		{
+			ActiveSessionHelper.InitializeSession(audioPlayerOptions);
+		}
 
 		player.FinishedPlaying += OnPlayerFinishedPlaying;
 		player.DecoderError += OnPlayerError;
@@ -327,6 +352,12 @@ partial class AudioPlayer : IAudioPlayer
 
 	void OnPlayerFinishedPlaying(object? sender, AVStatusEventArgs e)
 	{
+		// Stop the audio session to allow other aps audio to resume when audio is finished.
+		if (audioPlayerOptions.OnPlayAudioSession)
+		{
+			ActiveSessionHelper.FinishSession(audioPlayerOptions);
+		}
+
 		PlaybackEnded?.Invoke(this, e);
 	}
 }

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.macios.cs
@@ -27,7 +27,7 @@ partial class AudioPlayerOptions
 	/// </summary>
 	/// <remarks>
 	/// When enabled, the player will automatically create an audio session when playing, and close the audio session when stopped, finished, or paused.
-	/// When disabled, the player will create an audio session on initialisation, and only close this session on disposal.
+	/// When disabled, the player will create an audio session on initialization, and only close this session on disposal.
 	/// </remarks>
 	public bool OnPlayAudioSession { get; set; } = false;
 }

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.macios.cs
@@ -21,4 +21,13 @@ partial class AudioPlayerOptions
     /// See https://developer.apple.com/documentation/avfaudio/handling-audio-interruptions for more information.
     /// </remarks>
     public bool HandleAudioInterruptions { get; set; } = true;
+
+	/// <summary>
+	/// Gets or sets whether the audio session for this player should only be active while playing audio. Default value: <see langword="false"/>.
+	/// </summary>
+	/// <remarks>
+	/// When enabled, the player will automatically create an audio session when playing, and close the audio session when stopped, finished, or paused.
+	/// When disabled, the player will create an audio session on initialisation, and only close this session on disposal.
+	/// </remarks>
+	public bool OnPlayAudioSession { get; set; } = false;
 }

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayerOptions.macios.cs
@@ -24,10 +24,12 @@ partial class AudioPlayerOptions
 
 	/// <summary>
 	/// Gets or sets whether the audio session for this player should only be active while playing audio. Default value: <see langword="false"/>.
+	/// When set to true, a new audio session will be used each time audio is used. This means that interrupted audio sessions for other apps can be resumed/restored while you are not playing audio. 
+	/// This may be desirable for cases where you are playing short sounds such as notifications or text to speech, but may be undesirable for media playback.
 	/// </summary>
 	/// <remarks>
 	/// When enabled, the player will automatically create an audio session when playing, and close the audio session when stopped, finished, or paused.
 	/// When disabled, the player will create an audio session on initialization, and only close this session on disposal.
 	/// </remarks>
-	public bool OnPlayAudioSession { get; set; } = false;
+	public bool HandleAudioSessions { get; set; } = false;
 }


### PR DESCRIPTION
Added option to allow for audio session to be dynamically started and stopped on iOS (and mac).

When enabled this Starts the audio session on play, and stops the session on Pause/Stop/Finish.

Related to [issue](https://github.com/jfversluis/Plugin.Maui.Audio/issues/200)