### PR TITLE
Enable Bluetooth microphone recording and preferred input device selection (iOS/macCatalyst)

### DIFF
--- a/docs/audio-recorder.md
+++ b/docs/audio-recorder.md
@@ -75,7 +75,8 @@ To record from a specific Bluetooth device, use the `PreferredInput` property. T
 #if IOS || MACCATALYST
 using AVFoundation;
 
-// First, configure and activate the audio session to discover Bluetooth inputs
+// Configure and activate a temporary audio session to discover Bluetooth inputs.
+// The recorder will re-initialize the session with the same options when started.
 var audioSession = AVAudioSession.SharedInstance();
 audioSession.SetCategory(AVAudioSessionCategory.Record,
     AVAudioSessionCategoryOptions.AllowBluetooth, out _);
@@ -100,23 +101,14 @@ var recorder = audioManager.CreateRecorder(
 
 ### iOS 26+: High-quality Bluetooth recording
 
-Starting with iOS 26, Apple introduced `BluetoothHighQualityRecording` which enables full-bandwidth audio recording from supported Bluetooth devices (certain AirPods models). This removes the HFP 8–16 kHz limitation.
+Starting with iOS 26, Apple introduced a `bluetoothHighQualityRecording` category option which enables full-bandwidth audio recording from supported Bluetooth devices (certain AirPods models). This removes the HFP 8–16 kHz limitation.
 
 > [!WARNING]
 > This feature is iOS 26+ only (not macCatalyst), is **not available in the European Union**, increases input latency, and is not recommended for real-time communication. It requires the `default` audio session mode.
 
-The .NET `CategoryOptions` enum does not yet include this flag. You can enable it via `AVAudioApplication`:
+The .NET `AVAudioSessionCategoryOptions` enum does not yet include this flag. For apps using `AVCaptureSession`, it can be enabled via its `ConfiguresApplicationAudioSessionForBluetoothHighQualityRecording` property. Since this plugin uses `AVAudioRecorder`/`AVAudioSession`, the category option binding is needed — check future .NET SDK updates for availability.
 
-```csharp
-#if IOS
-if (OperatingSystem.IsIOSVersionAtLeast(26))
-{
-    AVAudioApplication.SharedInstance.ConfiguresApplicationAudioSessionForBluetoothHighQualityRecording = true;
-}
-#endif
-```
-
-To check if the connected device supports it:
+To check if a connected Bluetooth device supports high-quality recording:
 
 ```csharp
 var input = AVAudioSession.SharedInstance().CurrentRoute.Inputs.FirstOrDefault();
@@ -127,7 +119,7 @@ if (micExt?.HighQualityRecording.IsSupported == true)
 }
 ```
 
-Combine with `AllowBluetooth` for HFP fallback on unsupported devices or regions.
+In the meantime, combine with `AllowBluetooth` for HFP fallback on unsupported devices or regions.
 
 ## AudioRecorder API
 

--- a/docs/audio-recorder.md
+++ b/docs/audio-recorder.md
@@ -48,6 +48,56 @@ audioManager.CreateRecorder(
     });
 ```
 
+## Recording from a Bluetooth microphone (iOS/macCatalyst)
+
+By default, the recorder uses the system's built-in microphone. To enable recording from Bluetooth devices such as AirPods or other headsets, you need to opt in by setting `CategoryOptions` to `AllowBluetooth`. This makes Bluetooth HFP (Hands-Free Profile) devices available as recording inputs.
+
+> [!IMPORTANT]
+> Bluetooth HFP recording uses voice-quality audio (8–16 kHz, mono). This is a hardware limitation of the HFP profile. If high-fidelity recording is a priority and Bluetooth input is not needed, do not enable this option.
+
+### Basic Bluetooth recording
+
+```csharp
+audioManager.CreateRecorder(
+    new AudioRecorderOptions
+    {
+#if IOS || MACCATALYST
+        CategoryOptions = AVFoundation.AVAudioSessionCategoryOptions.AllowBluetooth
+#endif
+    });
+```
+
+### Selecting a specific Bluetooth device
+
+To record from a specific Bluetooth device, use the `PreferredInput` property. This requires enumerating the available inputs after the audio session has been configured:
+
+```csharp
+#if IOS || MACCATALYST
+using AVFoundation;
+
+// First, configure and activate the audio session to discover Bluetooth inputs
+var audioSession = AVAudioSession.SharedInstance();
+audioSession.SetCategory(AVAudioSessionCategory.Record,
+    AVAudioSessionCategoryOptions.AllowBluetooth, out _);
+audioSession.SetActive(true, out _);
+
+// Find the Bluetooth HFP input
+var btInput = audioSession.AvailableInputs?
+    .FirstOrDefault(i => i.PortType == AVAudioSession.PortBluetoothHfp);
+
+// Create the recorder with the preferred input
+var recorder = audioManager.CreateRecorder(
+    new AudioRecorderOptions
+    {
+        CategoryOptions = AVAudioSessionCategoryOptions.AllowBluetooth,
+        PreferredInput = btInput
+    });
+#endif
+```
+
+> [!NOTE]
+> `PreferredInput` must be set together with `CategoryOptions = AllowBluetooth` — without this option, Bluetooth HFP devices will not appear in `AvailableInputs`. No additional Bluetooth permissions are required beyond `NSMicrophoneUsageDescription` (iOS) and `com.apple.security.device.audio-input` (Mac Catalyst).
+
 ## AudioRecorder API
 
 Once you have created an `AudioRecorder` you can interact with it in the following ways:

--- a/docs/audio-recorder.md
+++ b/docs/audio-recorder.md
@@ -98,6 +98,37 @@ var recorder = audioManager.CreateRecorder(
 > [!NOTE]
 > `PreferredInput` must be set together with `CategoryOptions = AllowBluetooth` — without this option, Bluetooth HFP devices will not appear in `AvailableInputs`. No additional Bluetooth permissions are required beyond `NSMicrophoneUsageDescription` (iOS) and `com.apple.security.device.audio-input` (Mac Catalyst).
 
+### iOS 26+: High-quality Bluetooth recording
+
+Starting with iOS 26, Apple introduced `BluetoothHighQualityRecording` which enables full-bandwidth audio recording from supported Bluetooth devices (certain AirPods models). This removes the HFP 8–16 kHz limitation.
+
+> [!WARNING]
+> This feature is iOS 26+ only (not macCatalyst), is **not available in the European Union**, increases input latency, and is not recommended for real-time communication. It requires the `default` audio session mode.
+
+The .NET `CategoryOptions` enum does not yet include this flag. You can enable it via `AVAudioApplication`:
+
+```csharp
+#if IOS
+if (OperatingSystem.IsIOSVersionAtLeast(26))
+{
+    AVAudioApplication.SharedInstance.ConfiguresApplicationAudioSessionForBluetoothHighQualityRecording = true;
+}
+#endif
+```
+
+To check if the connected device supports it:
+
+```csharp
+var input = AVAudioSession.SharedInstance().CurrentRoute.Inputs.FirstOrDefault();
+var micExt = input?.BluetoothMicrophoneExtension;
+if (micExt?.HighQualityRecording.IsSupported == true)
+{
+    // Device supports high-quality Bluetooth recording
+}
+```
+
+Combine with `AllowBluetooth` for HFP fallback on unsupported devices or regions.
+
 ## AudioRecorder API
 
 Once you have created an `AudioRecorder` you can interact with it in the following ways:

--- a/docs/audio-streamer.md
+++ b/docs/audio-streamer.md
@@ -70,6 +70,22 @@ builder.UseMauiApp<App>()
 > [!NOTE]  
 > Currently only iOS and macOS have extra options that can be customized
 
+## Streaming from a Bluetooth microphone (iOS/macCatalyst)
+
+By default, the streamer uses the system's built-in microphone. To enable streaming from Bluetooth devices such as AirPods or other headsets, set `CategoryOptions` to `AllowBluetooth`. This makes Bluetooth HFP (Hands-Free Profile) devices available as streaming inputs.
+
+> [!IMPORTANT]
+> Bluetooth HFP audio is voice-quality (8–16 kHz, mono). This is a hardware limitation of the HFP profile.
+
+```csharp
+audioStreamer.Options.CategoryOptions = AVFoundation.AVAudioSessionCategoryOptions.AllowBluetooth;
+```
+
+To stream from a specific Bluetooth device, use the `PreferredInput` property — see the [recorder documentation](audio-recorder.md#selecting-a-specific-bluetooth-device) for a full example of enumerating available inputs.
+
+> [!NOTE]
+> No additional Bluetooth permissions are required beyond `NSMicrophoneUsageDescription` (iOS) and `com.apple.security.device.audio-input` (Mac Catalyst).
+
 ## AudioStreamer API
 
 Once you have created an `AudioStreamer` you can interact with it in the following ways:

--- a/samples/Plugin.Maui.Audio.Sample/Pages/AudioRecorderPage.xaml
+++ b/samples/Plugin.Maui.Audio.Sample/Pages/AudioRecorderPage.xaml
@@ -13,7 +13,7 @@
 
 	<ScrollView>
 		<Grid Margin="20" RowSpacing="10"
-			VerticalOptions="Center" RowDefinitions="*,*,*,*,*,*,*,*,*">
+			VerticalOptions="Center" RowDefinitions="*,*,*,*,*,*,*,*,*,*,*">
 
 			<Picker Grid.Row="0"
 					Title="Select Sample Rate"
@@ -35,23 +35,33 @@
 					ItemsSource="{Binding EncodingOptions}"
 					SelectedItem="{Binding SelectedEncoding, Mode=TwoWay}" />
 
-			<Button Grid.Row="4"
+			<HorizontalStackLayout Grid.Row="4" Spacing="10">
+				<Switch IsToggled="{Binding AllowBluetooth, Mode=TwoWay}" />
+				<Label Text="Allow Bluetooth (iOS/macOS)" VerticalOptions="Center" />
+			</HorizontalStackLayout>
+
+			<Picker Grid.Row="5"
+					Title="Select Input Device"
+					ItemsSource="{Binding InputDevices}"
+					SelectedItem="{Binding SelectedInputDevice, Mode=TwoWay}" />
+
+			<Button Grid.Row="6"
 					Text="Start Recording"
 					Command="{Binding StartCommand}" />
 
-			<Button Grid.Row="5"
+			<Button Grid.Row="7"
 					Text="Stop Recording"
 					Command="{Binding StopCommand}" />
 
-			<Button Grid.Row="6"
+			<Button Grid.Row="8"
 					Text="Play Recording"
 					Command="{Binding PlayCommand}" />
 
-			<Button Grid.Row="7"
+			<Button Grid.Row="9"
 					Text="Stop Play Recording"
 					Command="{Binding StopPlayCommand}" />
 
-			<Label Grid.Row="8" Text="{Binding RecordingTime, Converter={StaticResource SecondsToStringConverter}}" />
+			<Label Grid.Row="10" Text="{Binding RecordingTime, Converter={StaticResource SecondsToStringConverter}}" />
 		</Grid>
 
 	</ScrollView>

--- a/samples/Plugin.Maui.Audio.Sample/Pages/AudioRecorderPage.xaml
+++ b/samples/Plugin.Maui.Audio.Sample/Pages/AudioRecorderPage.xaml
@@ -37,7 +37,7 @@
 
 			<HorizontalStackLayout Grid.Row="4" Spacing="10">
 				<Switch IsToggled="{Binding AllowBluetooth, Mode=TwoWay}" />
-				<Label Text="Allow Bluetooth (iOS/macOS)" VerticalOptions="Center" />
+				<Label Text="Allow Bluetooth (required on iOS only)" VerticalOptions="Center" />
 			</HorizontalStackLayout>
 
 			<Picker Grid.Row="5"

--- a/samples/Plugin.Maui.Audio.Sample/Pages/AudioStreamerPage.xaml
+++ b/samples/Plugin.Maui.Audio.Sample/Pages/AudioStreamerPage.xaml
@@ -34,7 +34,7 @@
 
 			<HorizontalStackLayout Grid.Row="3" Spacing="10">
 				<Switch IsToggled="{Binding AllowBluetooth, Mode=TwoWay}" />
-				<Label Text="Allow Bluetooth (iOS/macOS)" VerticalOptions="Center" />
+				<Label Text="Allow Bluetooth (required on iOS only)" VerticalOptions="Center" />
 			</HorizontalStackLayout>
 
 			<Picker Grid.Row="4"

--- a/samples/Plugin.Maui.Audio.Sample/Pages/AudioStreamerPage.xaml
+++ b/samples/Plugin.Maui.Audio.Sample/Pages/AudioStreamerPage.xaml
@@ -15,7 +15,7 @@
 	<ScrollView>
 		<Grid HorizontalOptions="Fill" Margin="20"
 			RowSpacing="10" VerticalOptions="Center"
-			RowDefinitions="*,*,*,*,*,*,*,*,*,*,*,*">
+			RowDefinitions="*,*,*,*,*,*,*,*,*,*,*,*,*,*">
 
 			<Picker Grid.Row="0"
 					Title="Select Sample Rate"
@@ -32,19 +32,29 @@
 					ItemsSource="{Binding BitDepths}"
 					SelectedItem="{Binding SelectedBitDepth, Mode=TwoWay}" />
 
-			<Button Grid.Row="3"
+			<HorizontalStackLayout Grid.Row="3" Spacing="10">
+				<Switch IsToggled="{Binding AllowBluetooth, Mode=TwoWay}" />
+				<Label Text="Allow Bluetooth (iOS/macOS)" VerticalOptions="Center" />
+			</HorizontalStackLayout>
+
+			<Picker Grid.Row="4"
+					Title="Select Input Device"
+					ItemsSource="{Binding InputDevices}"
+					SelectedItem="{Binding SelectedInputDevice, Mode=TwoWay}" />
+
+			<Button Grid.Row="5"
 					Text="Start Recording"
 					Command="{Binding StartCommand}" />
 
-			<Button Grid.Row="4"
+			<Button Grid.Row="6"
 					Text="Stop Recording"
 					Command="{Binding StopCommand}" />
 
-			<Button Grid.Row="5"
+			<Button Grid.Row="7"
 					Text="Play Recording"
 					Command="{Binding PlayCommand}" />
 
-			<Grid Grid.Row="6" ColumnDefinitions="*, *" ColumnSpacing="5">
+			<Grid Grid.Row="8" ColumnDefinitions="*, *" ColumnSpacing="5">
 				<Button Grid.Column="0"
 						Text="Left"
 				        Command="{Binding PlayLeftCommand}" />
@@ -53,14 +63,14 @@
 				        Command="{Binding PlayRightCommand}" />
 			</Grid>
 
-			<Button Grid.Row="7"
+			<Button Grid.Row="9"
 					Text="Stop Play Recording"
 					Command="{Binding StopPlayCommand}" />
 
-			<Label Grid.Row="8" Text="{Binding RecordingTime, Converter={StaticResource SecondsToStringConverter}}" />
-			<Label Grid.Row="9" Text="{Binding MeasuredDecibel, Converter={StaticResource DecibelToStringConverter}}" />
+			<Label Grid.Row="10" Text="{Binding RecordingTime, Converter={StaticResource SecondsToStringConverter}}" />
+			<Label Grid.Row="11" Text="{Binding MeasuredDecibel, Converter={StaticResource DecibelToStringConverter}}" />
 
-			<Label Grid.Row="10">
+			<Label Grid.Row="12">
 				<Label.FormattedText>
 					<FormattedString>
 						<Span Text="Rms: " />
@@ -69,7 +79,7 @@
 				</Label.FormattedText>
 			</Label>
 
-			<Label Grid.Row="11">
+			<Label Grid.Row="13">
 				<Label.FormattedText>
 					<FormattedString>
 						<Span Text="IsSilent: " />

--- a/samples/Plugin.Maui.Audio.Sample/ViewModels/AudioRecorderPageViewModel.cs
+++ b/samples/Plugin.Maui.Audio.Sample/ViewModels/AudioRecorderPageViewModel.cs
@@ -147,6 +147,7 @@ public class AudioRecorderPageViewModel : BaseViewModel
 		{
 			allowBluetooth = value;
 			NotifyPropertyChanged();
+			LoadInputDevices();
 		}
 	}
 
@@ -154,6 +155,16 @@ public class AudioRecorderPageViewModel : BaseViewModel
 	{
 #if IOS || MACCATALYST
 		var session = AVAudioSession.SharedInstance();
+
+		// On iOS, AllowBluetooth is required for BT devices to appear in AvailableInputs.
+		// On macCatalyst, devices appear regardless but setting AllowBluetooth is harmless.
+		var categoryOptions = AllowBluetooth
+			? AVAudioSessionCategoryOptions.AllowBluetooth
+			: AVAudioSessionCategoryOptions.DefaultToSpeaker;
+
+		session.SetCategory(AVAudioSessionCategory.PlayAndRecord, AVAudioSessionMode.Default, categoryOptions, out _);
+		session.SetActive(true, out _);
+
 		availableInputPorts = session.AvailableInputs ?? [];
 
 		var devices = new List<string> { "Default" };

--- a/samples/Plugin.Maui.Audio.Sample/ViewModels/AudioRecorderPageViewModel.cs
+++ b/samples/Plugin.Maui.Audio.Sample/ViewModels/AudioRecorderPageViewModel.cs
@@ -1,5 +1,8 @@
 ﻿using System.Diagnostics;
 using static Microsoft.Maui.ApplicationModel.Permissions;
+#if IOS || MACCATALYST
+using AVFoundation;
+#endif
 
 namespace Plugin.Maui.Audio.Sample.ViewModels;
 
@@ -12,6 +15,10 @@ public class AudioRecorderPageViewModel : BaseViewModel
 	IAudioSource audioSource = null;
 	readonly Stopwatch recordingStopwatch = new Stopwatch();
 	bool isPlaying;
+
+#if IOS || MACCATALYST
+	AVAudioSessionPortDescription[] availableInputPorts = [];
+#endif
 
 	public double RecordingTime
 	{
@@ -50,6 +57,8 @@ public class AudioRecorderPageViewModel : BaseViewModel
 
 		this.audioManager = audioManager;
 		this.dispatcher = dispatcher;
+
+		LoadInputDevices();
 	}
 
 	ChannelType selectedChannelType;
@@ -108,6 +117,56 @@ public class AudioRecorderPageViewModel : BaseViewModel
 		48000
 	];
 
+	List<string> inputDevices = ["Default"];
+	public List<string> InputDevices
+	{
+		get => inputDevices;
+		set
+		{
+			inputDevices = value;
+			NotifyPropertyChanged();
+		}
+	}
+
+	string selectedInputDevice = "Default";
+	public string SelectedInputDevice
+	{
+		get => selectedInputDevice;
+		set
+		{
+			selectedInputDevice = value;
+			NotifyPropertyChanged();
+		}
+	}
+
+	bool allowBluetooth;
+	public bool AllowBluetooth
+	{
+		get => allowBluetooth;
+		set
+		{
+			allowBluetooth = value;
+			NotifyPropertyChanged();
+		}
+	}
+
+	void LoadInputDevices()
+	{
+#if IOS || MACCATALYST
+		var session = AVAudioSession.SharedInstance();
+		availableInputPorts = session.AvailableInputs ?? [];
+
+		var devices = new List<string> { "Default" };
+		foreach (var port in availableInputPorts)
+		{
+			devices.Add(port.PortName);
+		}
+
+		InputDevices = devices;
+		SelectedInputDevice = "Default";
+#endif
+	}
+
 
 	async void PlayAudio()
 	{
@@ -146,6 +205,22 @@ public class AudioRecorderPageViewModel : BaseViewModel
 			{
 				options.SampleRate = SelectedSampleRate;
 			}
+
+#if IOS || MACCATALYST
+			if (AllowBluetooth)
+			{
+				options.CategoryOptions = AVAudioSessionCategoryOptions.AllowBluetooth;
+			}
+
+			if (SelectedInputDevice != "Default")
+			{
+				var selectedPort = availableInputPorts.FirstOrDefault(p => p.PortName == SelectedInputDevice);
+				if (selectedPort is not null)
+				{
+					options.PreferredInput = selectedPort;
+				}
+			}
+#endif
 
 			try
 			{

--- a/samples/Plugin.Maui.Audio.Sample/ViewModels/AudioStreamerPageViewModel.cs
+++ b/samples/Plugin.Maui.Audio.Sample/ViewModels/AudioStreamerPageViewModel.cs
@@ -1,5 +1,8 @@
 ﻿using System.Diagnostics;
 using Plugin.Maui.Audio.AudioListeners;
+#if IOS || MACCATALYST
+using AVFoundation;
+#endif
 
 namespace Plugin.Maui.Audio.Sample.ViewModels;
 
@@ -24,6 +27,10 @@ public class AudioStreamerPageViewModel : BaseViewModel
 	string capturedAudioWavFileLeft;
 	string capturedAudioWavFileRight;
 
+#if IOS || MACCATALYST
+	AVAudioSessionPortDescription[] availableInputPorts = [];
+#endif
+
 	public AudioStreamerPageViewModel(
 		IAudioManager audioManager,
 		IDispatcher dispatcher)
@@ -39,6 +46,7 @@ public class AudioStreamerPageViewModel : BaseViewModel
 		this.dispatcher = dispatcher;
 
 		SetDefaults();
+		LoadInputDevices();
 	}
 
 	double measuredDecibel;
@@ -72,6 +80,56 @@ public class AudioStreamerPageViewModel : BaseViewModel
 		44100,
 		48000
 	];
+
+	List<string> inputDevices = ["Default"];
+	public List<string> InputDevices
+	{
+		get => inputDevices;
+		set
+		{
+			inputDevices = value;
+			NotifyPropertyChanged();
+		}
+	}
+
+	string selectedInputDevice = "Default";
+	public string SelectedInputDevice
+	{
+		get => selectedInputDevice;
+		set
+		{
+			selectedInputDevice = value;
+			NotifyPropertyChanged();
+		}
+	}
+
+	bool allowBluetooth;
+	public bool AllowBluetooth
+	{
+		get => allowBluetooth;
+		set
+		{
+			allowBluetooth = value;
+			NotifyPropertyChanged();
+		}
+	}
+
+	void LoadInputDevices()
+	{
+#if IOS || MACCATALYST
+		var session = AVAudioSession.SharedInstance();
+		availableInputPorts = session.AvailableInputs ?? [];
+
+		var devices = new List<string> { "Default" };
+		foreach (var port in availableInputPorts)
+		{
+			devices.Add(port.PortName);
+		}
+
+		InputDevices = devices;
+		SelectedInputDevice = "Default";
+#endif
+	}
 
 	public double RecordingTime => recordingStopwatch.ElapsedMilliseconds / 1000;
 
@@ -247,6 +305,22 @@ public class AudioStreamerPageViewModel : BaseViewModel
 			audioStreamer.Options.Channels = SelectedChannelType;
 			audioStreamer.Options.BitDepth = SelectedBitDepth;
 			audioStreamer.Options.SampleRate = SelectedSampleRate;
+
+#if IOS || MACCATALYST
+			if (AllowBluetooth)
+			{
+				audioStreamer.Options.CategoryOptions = AVAudioSessionCategoryOptions.AllowBluetooth;
+			}
+
+			if (SelectedInputDevice != "Default")
+			{
+				var selectedPort = availableInputPorts.FirstOrDefault(p => p.PortName == SelectedInputDevice);
+				if (selectedPort is not null)
+				{
+					audioStreamer.Options.PreferredInput = selectedPort;
+				}
+			}
+#endif
 
 			try
 			{

--- a/samples/Plugin.Maui.Audio.Sample/ViewModels/AudioStreamerPageViewModel.cs
+++ b/samples/Plugin.Maui.Audio.Sample/ViewModels/AudioStreamerPageViewModel.cs
@@ -111,6 +111,7 @@ public class AudioStreamerPageViewModel : BaseViewModel
 		{
 			allowBluetooth = value;
 			NotifyPropertyChanged();
+			LoadInputDevices();
 		}
 	}
 
@@ -118,6 +119,13 @@ public class AudioStreamerPageViewModel : BaseViewModel
 	{
 #if IOS || MACCATALYST
 		var session = AVAudioSession.SharedInstance();
+
+		var categoryOptions = AllowBluetooth
+			? AVAudioSessionCategoryOptions.AllowBluetooth
+			: AVAudioSessionCategoryOptions.DefaultToSpeaker;
+
+		session.SetCategory(AVAudioSessionCategory.PlayAndRecord, AVAudioSessionMode.Default, categoryOptions, out _);
+
 		availableInputPorts = session.AvailableInputs ?? [];
 
 		var devices = new List<string> { "Default" };

--- a/src/Plugin.Maui.Audio/ActiveSessionHelper.macios.cs
+++ b/src/Plugin.Maui.Audio/ActiveSessionHelper.macios.cs
@@ -22,6 +22,15 @@ internal class ActiveSessionHelper
 			Trace.TraceError("failed activate audio session");
 			Trace.TraceError(error.ToString());
 		}
+
+		if (options.PreferredInput is not null)
+		{
+			audioSession.SetPreferredInput(options.PreferredInput, out var inputError);
+			if (inputError is not null)
+			{
+				Trace.TraceError($"failed to set preferred input: {inputError}");
+			}
+		}
     }
 
     public static void FinishSession(BaseOptions options)

--- a/src/Plugin.Maui.Audio/ActiveSessionHelper.macios.cs
+++ b/src/Plugin.Maui.Audio/ActiveSessionHelper.macios.cs
@@ -23,7 +23,7 @@ internal class ActiveSessionHelper
 			Trace.TraceError(error.ToString());
 		}
 
-		if (options.PreferredInput is not null)
+		if (error is null && options.PreferredInput is not null)
 		{
 			audioSession.SetPreferredInput(options.PreferredInput, out var inputError);
 			if (inputError is not null)

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorderOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorderOptions.macios.cs
@@ -6,13 +6,15 @@ partial class AudioRecorderOptions
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AudioRecorderOptions"/> class with default settings for macOS/iOS.
-    /// Sets the audio session category to <see cref="AVAudioSessionCategory.Record"/> with
-    /// <see cref="AVAudioSessionCategoryOptions.AllowBluetooth"/> enabled so that Bluetooth
-    /// microphones (e.g. AirPods, headsets) are available as recording inputs.
+    /// Sets the audio session category to <see cref="AVAudioSessionCategory.Record"/>.
+    /// <para>
+    /// To enable Bluetooth microphone recording (e.g. AirPods, headsets), set
+    /// <see cref="BaseOptions.CategoryOptions"/> to <see cref="AVAudioSessionCategoryOptions.AllowBluetooth"/>
+    /// and optionally set <see cref="BaseOptions.PreferredInput"/> to route to a specific device.
+    /// </para>
     /// </summary>
     public AudioRecorderOptions()
     {
         Category = AVAudioSessionCategory.Record;
-        CategoryOptions = AVAudioSessionCategoryOptions.AllowBluetooth;
     }
 }

--- a/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorderOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioRecorder/AudioRecorderOptions.macios.cs
@@ -6,9 +6,13 @@ partial class AudioRecorderOptions
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AudioRecorderOptions"/> class with default settings for macOS/iOS.
+    /// Sets the audio session category to <see cref="AVAudioSessionCategory.Record"/> with
+    /// <see cref="AVAudioSessionCategoryOptions.AllowBluetooth"/> enabled so that Bluetooth
+    /// microphones (e.g. AirPods, headsets) are available as recording inputs.
     /// </summary>
     public AudioRecorderOptions()
     {
         Category = AVAudioSessionCategory.Record;
+        CategoryOptions = AVAudioSessionCategoryOptions.AllowBluetooth;
     }
 }

--- a/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamOptions.macios.cs
@@ -6,13 +6,15 @@ public partial class AudioStreamOptions
 {
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AudioStreamOptions"/> class with default settings for macOS/iOS.
-	/// Sets the audio session category to <see cref="AVAudioSessionCategory.Record"/> with
-	/// <see cref="AVAudioSessionCategoryOptions.AllowBluetooth"/> enabled so that Bluetooth
-	/// microphones (e.g. AirPods, headsets) are available as streaming inputs.
+	/// Sets the audio session category to <see cref="AVAudioSessionCategory.Record"/>.
+	/// <para>
+	/// To enable Bluetooth microphone streaming (e.g. AirPods, headsets), set
+	/// <see cref="BaseOptions.CategoryOptions"/> to <see cref="AVAudioSessionCategoryOptions.AllowBluetooth"/>
+	/// and optionally set <see cref="BaseOptions.PreferredInput"/> to route to a specific device.
+	/// </para>
 	/// </summary>
 	public AudioStreamOptions()
 	{
 		Category = AVAudioSessionCategory.Record;
-		CategoryOptions = AVAudioSessionCategoryOptions.AllowBluetooth;
 	}
 }

--- a/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioStreamer/AudioStreamOptions.macios.cs
@@ -6,9 +6,13 @@ public partial class AudioStreamOptions
 {
 	/// <summary>
 	/// Initializes a new instance of the <see cref="AudioStreamOptions"/> class with default settings for macOS/iOS.
+	/// Sets the audio session category to <see cref="AVAudioSessionCategory.Record"/> with
+	/// <see cref="AVAudioSessionCategoryOptions.AllowBluetooth"/> enabled so that Bluetooth
+	/// microphones (e.g. AirPods, headsets) are available as streaming inputs.
 	/// </summary>
 	public AudioStreamOptions()
 	{
 		Category = AVAudioSessionCategory.Record;
+		CategoryOptions = AVAudioSessionCategoryOptions.AllowBluetooth;
 	}
 }

--- a/src/Plugin.Maui.Audio/BaseOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/BaseOptions.macios.cs
@@ -37,6 +37,11 @@ partial class BaseOptions
     /// documentation, <c>SetPreferredInput</c> must be called after setting the session
     /// category and activating the session.
     /// </para>
+    /// <para>
+    /// <b>Note:</b> For Bluetooth HFP microphones to appear in
+    /// <see cref="AVAudioSession.AvailableInputs"/>, the <see cref="BaseOptions.CategoryOptions"/>
+    /// must include <see cref="AVAudioSessionCategoryOptions.AllowBluetooth"/>.
+    /// </para>
     /// </summary>
     public AVAudioSessionPortDescription? PreferredInput { get; set; }
 }

--- a/src/Plugin.Maui.Audio/BaseOptions.macios.cs
+++ b/src/Plugin.Maui.Audio/BaseOptions.macios.cs
@@ -23,4 +23,20 @@ partial class BaseOptions
     /// Gets or sets the lifetime of the underlying audio session - basically whether the AVAudioSession will stay active or be deactivated.
     /// </summary>
     public SessionLifetime SessionLifetime { get; set; } = default;
+
+    /// <summary>
+    /// Gets or sets the preferred input port for recording.
+    /// <para>
+    /// Set this to an <see cref="AVAudioSessionPortDescription"/> obtained from
+    /// <see cref="AVAudioSession.AvailableInputs"/> to record from a specific device
+    /// (e.g. a Bluetooth headset or external microphone). When <see langword="null"/>,
+    /// the system default input device is used.
+    /// </para>
+    /// <para>
+    /// The preferred input is applied after the audio session is activated. Per Apple's
+    /// documentation, <c>SetPreferredInput</c> must be called after setting the session
+    /// category and activating the session.
+    /// </para>
+    /// </summary>
+    public AVAudioSessionPortDescription? PreferredInput { get; set; }
 }


### PR DESCRIPTION
## Context

Bluetooth microphone recording on iOS/macCatalyst was already possible by manually setting `CategoryOptions = AllowBluetooth` on `AudioRecorderOptions` or `AudioStreamOptions` (available since PR #101). However, this was undocumented and there was no way to select a **specific** input device through the plugin API.

This was identified while investigating a [MAUI app that records silence when AirPods are connected](https://github.com/Jandev/realtime-transcribe) — the app author was unaware of the `CategoryOptions` property.

## What's new in this PR

### 1. New `PreferredInput` property on `BaseOptions` (iOS/macCatalyst)

A new `AVAudioSessionPortDescription? PreferredInput` property allows consumers to select a specific input device (e.g. a particular Bluetooth headset when multiple are paired):

```csharp
var session = AVAudioSession.SharedInstance();
var btMic = session.AvailableInputs?.FirstOrDefault(p => 
    p.PortType == AVAudioSession.PortBluetoothHfp);

var recorder = audioManager.CreateRecorder(new AudioRecorderOptions
{
    CategoryOptions = AVAudioSessionCategoryOptions.AllowBluetooth,
    PreferredInput = btMic
});
```

### 2. `SetPreferredInput` wiring in `ActiveSessionHelper`

`InitializeSession` now calls `SetPreferredInput` after activating the session, following Apple's required ordering: `SetCategory` → `SetActive` → `SetPreferredInput`. Skipped if session activation fails.

### 3. Comprehensive documentation

- Added Bluetooth recording section to `audio-recorder.md` with full code examples for both basic usage and device selection
- Added Bluetooth streaming section to `audio-streamer.md`
- Documented HFP quality limitation (8–16 kHz, mono)
- Documented iOS 26 `BluetoothHighQualityRecording` API (not yet available via .NET CategoryOptions binding)
- Clarified that no extra Bluetooth permissions are needed beyond `NSMicrophoneUsageDescription` and `com.apple.security.device.audio-input`

### What was already possible (no change needed)

Setting `CategoryOptions = AllowBluetooth` to enable Bluetooth HFP microphones was already supported — this PR does **not** change that default. The existing opt-in mechanism continues to work as before.

## References
- Apple docs: [allowBluetooth](https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions-swift.struct/allowbluetooth)
- Apple docs: [setPreferredInput](https://developer.apple.com/documentation/avfaudio/avaudiosession/setpreferredinput(_:))
- Apple docs: [bluetoothHighQualityRecording](https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions-swift.struct/bluetoothhighqualityrecording) (iOS 26+)