### PR TITLE
Update SkiaSharp.Extended.UI.Maui to 3.0.0 (fix 16KB page size warnings)

### DIFF
--- a/samples/Plugin.Maui.Audio.Sample/Plugin.Maui.Audio.Sample.csproj
+++ b/samples/Plugin.Maui.Audio.Sample/Plugin.Maui.Audio.Sample.csproj
@@ -48,7 +48,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="SkiaSharp.Extended.UI.Maui" Version="2.0.0" />
+	  <PackageReference Include="SkiaSharp.Extended.UI.Maui" Version="3.0.0" />
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Updates SkiaSharp.Extended.UI.Maui from 2.0.0 to 3.0.0 in the sample app.

This fixes the 16KB page size alignment warnings on Android caused by native .so libraries in the older SkiaSharp version not being aligned to 16KB pages (required by Google Play since Nov 2025).