### PR TITLE
Fix AudioPlayer disposal reentrancy

### DIFF
--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -141,7 +141,7 @@ partial class AudioPlayer : IAudioPlayer
 			player.DecoderError -= OnPlayerError;
 			UnregisterFromAudioInterruptions();
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);
-			Stop();
+			Stop(false);
 			player.Dispose();
 		}
 
@@ -208,6 +208,8 @@ partial class AudioPlayer : IAudioPlayer
 			return;
 		}
 
+		isDisposed = true;
+
 		if (disposing)
 		{
 			// If this player set the port override, decrement ref count
@@ -235,13 +237,11 @@ partial class AudioPlayer : IAudioPlayer
 			UnregisterFromAudioInterruptions();
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);
 
-			Stop();
-
 			player.FinishedPlaying -= OnPlayerFinishedPlaying;
+			player.DecoderError -= OnPlayerError;
+			Stop(false);
 			player.Dispose();
 		}
-
-		isDisposed = true;
 	}
 
 	/// <summary>
@@ -278,9 +278,18 @@ partial class AudioPlayer : IAudioPlayer
 	/// </summary>
 	public void Stop()
 	{
+		Stop(true);
+	}
+
+	void Stop(bool raisePlaybackEnded)
+	{
 		player.Stop();
 		Seek(0);
-		PlaybackEnded?.Invoke(this, EventArgs.Empty);
+
+		if (raisePlaybackEnded)
+		{
+			PlaybackEnded?.Invoke(this, EventArgs.Empty);
+		}
 	}
 
 	bool PreparePlayer()
@@ -443,6 +452,11 @@ partial class AudioPlayer : IAudioPlayer
 
 	void OnPlayerFinishedPlaying(object? sender, AVStatusEventArgs e)
 	{
+		if (isDisposed)
+		{
+			return;
+		}
+
 		PlaybackEnded?.Invoke(this, e);
 	}
 }

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
@@ -151,6 +151,11 @@ partial class AudioPlayer : IAudioPlayer
 
 	void OnPlaybackEnded(MediaPlayer sender, object args)
 	{
+		if (isDisposed)
+		{
+			return;
+		}
+
 		PlaybackEnded?.Invoke(sender, EventArgs.Empty);
 	}
 
@@ -177,9 +182,18 @@ partial class AudioPlayer : IAudioPlayer
 
 	public void Stop()
 	{
+		Stop(true);
+	}
+
+	void Stop(bool raisePlaybackEnded)
+	{
 		Pause();
 		Seek(0);
-		OnPlaybackEnded(player, EventArgs.Empty); //todo check for double invoke?
+
+		if (raisePlaybackEnded)
+		{
+			OnPlaybackEnded(player, EventArgs.Empty);
+		}
 	}
 
 	public void Seek(double position)
@@ -258,16 +272,15 @@ partial class AudioPlayer : IAudioPlayer
 			return;
 		}
 
+		isDisposed = true;
+
 		if (disposing)
 		{
-			Stop();
-
 			player.MediaFailed -= OnError;
 			player.MediaEnded -= OnPlaybackEnded;
+			Stop(false);
 			player.Dispose();
 		}
-
-		isDisposed = true;
 	}
 }
 
@@ -285,4 +298,3 @@ public class MediaPlayerFailedEventArgsWrapper : EventArgs
 		ErrorMessage = args.Error.ToString();
 	}
 }
-


### PR DESCRIPTION
## Description

Hardens the Windows `AudioPlayer` completion/disposal path so disposing from `PlaybackEnded` cannot recurse or deliver a queued completion after disposal.

- Keeps explicit `Stop()` behavior unchanged: it still raises `PlaybackEnded`.
- Uses a non-notifying internal stop during disposal.
- Marks the player disposed before teardown and ignores completion callbacks after disposal.
- Incorporates the merged #219 Apple disposal fix without changing its deferred callback behavior.

Fixes #214.

A dedicated regression test is not included because the repository has no test project and this behavior depends on native `MediaPlayer` callbacks. The Windows plugin/sample CI builds and generated NuGet artifact provide the practical validation path.

## Platforms Affected

- [ ] Android
- [ ] iOS
- [ ] macOS (Catalyst)
- [x] Windows

## Breaking Changes

None.

## Checklist

- [x] Plugin builds successfully
- [ ] Sample builds (CI)
- [x] New public APIs have XML docs (N/A; no public API changes)
- [x] README updated (N/A; no API changes)