### PR TITLE
Fix iOS crash when disposing a completed audio player

### DIFF
--- a/docs/audio-player.md
+++ b/docs/audio-player.md
@@ -149,13 +149,19 @@ var player = audioManager.CreatePlayer(
 #endif
     });
 
-player.PlaybackEnded += (s, e) => player.Dispose();
+void OnPlaybackEnded(object? sender, EventArgs e)
+{
+    player.PlaybackEnded -= OnPlaybackEnded;
+    player.Dispose();
+}
+
+player.PlaybackEnded += OnPlaybackEnded;
 player.Play();
 // When playback ends → player disposes → session deactivates → other apps resume
 ```
 
 > [!TIP]
-> For repeated short sounds, create a new player each time rather than caching one. The overhead is minimal and this properly manages the shared audio session lifecycle without conflicting with other players or recorders.
+> Unsubscribe from `PlaybackEnded` before disposing the player to prevent disposal from raising the same handler again. For repeated short sounds, create a new player each time rather than caching one. The overhead is minimal and this properly manages the shared audio session lifecycle without conflicting with other players or recorders.
 
 ## Controlling Audio Output Device/Port
 

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.android.cs
@@ -660,6 +660,8 @@ partial class AudioPlayer : IAudioPlayer
 			return;
 		}
 
+		isDisposed = true;
+
 		if (disposing)
 		{
 			AbandonAudioFocus();
@@ -673,8 +675,6 @@ partial class AudioPlayer : IAudioPlayer
 			stream?.Dispose();
 			audioFocusRequest?.Dispose();
 		}
-
-		isDisposed = true;
 	}
 
 	/// <summary>

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -12,6 +12,7 @@ partial class AudioPlayer : IAudioPlayer
 	readonly AudioPlayerOptions audioPlayerOptions;
 	bool isDisposed;
 	int playerGeneration;
+	int playbackGeneration;
 	EventHandler<AVStatusEventArgs>? finishedPlayingHandler;
 	NSObject? interruptionObserver;
 	bool wasPlayingBeforeInterruption = false;
@@ -266,6 +267,8 @@ partial class AudioPlayer : IAudioPlayer
 	/// </summary>
 	public void Play()
 	{
+		Interlocked.Increment(ref playbackGeneration);
+
 		if (player.Playing)
 		{
 			player.Pause();
@@ -290,6 +293,7 @@ partial class AudioPlayer : IAudioPlayer
 	/// </summary>
 	public void Stop()
 	{
+		Interlocked.Increment(ref playbackGeneration);
 		player.Stop();
 		Seek(0);
 		PlaybackEnded?.Invoke(this, EventArgs.Empty);
@@ -458,10 +462,13 @@ partial class AudioPlayer : IAudioPlayer
 
 	void OnPlayerFinishedPlaying(AVAudioPlayer finishedPlayer, int generation, AVStatusEventArgs e)
 	{
+		var completedPlaybackGeneration = Volatile.Read(ref playbackGeneration);
+
 		NSRunLoop.Main.BeginInvokeOnMainThread(() =>
 		{
 			if (!isDisposed &&
 				generation == Volatile.Read(ref playerGeneration) &&
+				completedPlaybackGeneration == Volatile.Read(ref playbackGeneration) &&
 				ReferenceEquals(player, finishedPlayer))
 			{
 				PlaybackEnded?.Invoke(this, e);

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -11,6 +11,7 @@ partial class AudioPlayer : IAudioPlayer
 	AVAudioPlayer player;
 	readonly AudioPlayerOptions audioPlayerOptions;
 	bool isDisposed;
+	// Monotonic tokens invalidate deferred callbacks; these are versions, not reference counts.
 	int playerGeneration;
 	int playbackGeneration;
 	EventHandler<AVStatusEventArgs>? finishedPlayingHandler;

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -279,6 +279,7 @@ partial class AudioPlayer : IAudioPlayer
 			player.CurrentTime = 0;
 		}
 
+		SubscribeToFinishedPlaying();
 		player.Play();
 	}
 
@@ -306,10 +307,8 @@ partial class AudioPlayer : IAudioPlayer
 		// Set preferred output port if specified
 		SetPreferredOutputPort(audioPlayerOptions.PreferredOutputPort);
 
-		var preparedPlayer = player;
-		var generation = Interlocked.Increment(ref playerGeneration);
-		finishedPlayingHandler = (_, e) => OnPlayerFinishedPlaying(preparedPlayer, generation, e);
-		player.FinishedPlaying += finishedPlayingHandler;
+		Interlocked.Increment(ref playerGeneration);
+		SubscribeToFinishedPlaying();
 		player.DecoderError += OnPlayerError;
 
 		// Subscribe to audio session interruptions
@@ -319,6 +318,21 @@ partial class AudioPlayer : IAudioPlayer
 		player.PrepareToPlay();
 
 		return true;
+	}
+
+	void SubscribeToFinishedPlaying()
+	{
+		if (finishedPlayingHandler is not null)
+		{
+			player.FinishedPlaying -= finishedPlayingHandler;
+		}
+
+		var preparedPlayer = player;
+		var generation = Volatile.Read(ref playerGeneration);
+		var preparedPlaybackGeneration = Volatile.Read(ref playbackGeneration);
+		finishedPlayingHandler = (_, e) =>
+			OnPlayerFinishedPlaying(preparedPlayer, generation, preparedPlaybackGeneration, e);
+		player.FinishedPlaying += finishedPlayingHandler;
 	}
 
 	void SetPreferredOutputPort(AudioOutputPort preferredPort)
@@ -460,9 +474,16 @@ partial class AudioPlayer : IAudioPlayer
 		OnError(e);
 	}
 
-	void OnPlayerFinishedPlaying(AVAudioPlayer finishedPlayer, int generation, AVStatusEventArgs e)
+	void OnPlayerFinishedPlaying(
+		AVAudioPlayer finishedPlayer,
+		int generation,
+		int completedPlaybackGeneration,
+		AVStatusEventArgs e)
 	{
-		var completedPlaybackGeneration = Volatile.Read(ref playbackGeneration);
+		if (finishedPlayer.Playing)
+		{
+			return;
+		}
 
 		NSRunLoop.Main.BeginInvokeOnMainThread(() =>
 		{

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.macios.cs
@@ -11,6 +11,8 @@ partial class AudioPlayer : IAudioPlayer
 	AVAudioPlayer player;
 	readonly AudioPlayerOptions audioPlayerOptions;
 	bool isDisposed;
+	int playerGeneration;
+	EventHandler<AVStatusEventArgs>? finishedPlayingHandler;
 	NSObject? interruptionObserver;
 	bool wasPlayingBeforeInterruption = false;
 	bool hasSetPortOverride;
@@ -137,11 +139,16 @@ partial class AudioPlayer : IAudioPlayer
 	{
 		if (player != null)
 		{
-			player.FinishedPlaying -= OnPlayerFinishedPlaying;
+			Interlocked.Increment(ref playerGeneration);
+			if (finishedPlayingHandler is not null)
+			{
+				player.FinishedPlaying -= finishedPlayingHandler;
+			}
 			player.DecoderError -= OnPlayerError;
 			UnregisterFromAudioInterruptions();
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);
-			Stop();
+			player.Stop();
+			player.CurrentTime = 0;
 			player.Dispose();
 		}
 
@@ -208,6 +215,9 @@ partial class AudioPlayer : IAudioPlayer
 			return;
 		}
 
+		isDisposed = true;
+		Interlocked.Increment(ref playerGeneration);
+
 		if (disposing)
 		{
 			// If this player set the port override, decrement ref count
@@ -235,13 +245,15 @@ partial class AudioPlayer : IAudioPlayer
 			UnregisterFromAudioInterruptions();
 			ActiveSessionHelper.FinishSession(audioPlayerOptions);
 
-			Stop();
-
-			player.FinishedPlaying -= OnPlayerFinishedPlaying;
+			if (finishedPlayingHandler is not null)
+			{
+				player.FinishedPlaying -= finishedPlayingHandler;
+			}
+			player.DecoderError -= OnPlayerError;
+			player.Stop();
+			player.CurrentTime = 0;
 			player.Dispose();
 		}
-
-		isDisposed = true;
 	}
 
 	/// <summary>
@@ -290,7 +302,10 @@ partial class AudioPlayer : IAudioPlayer
 		// Set preferred output port if specified
 		SetPreferredOutputPort(audioPlayerOptions.PreferredOutputPort);
 
-		player.FinishedPlaying += OnPlayerFinishedPlaying;
+		var preparedPlayer = player;
+		var generation = Interlocked.Increment(ref playerGeneration);
+		finishedPlayingHandler = (_, e) => OnPlayerFinishedPlaying(preparedPlayer, generation, e);
+		player.FinishedPlaying += finishedPlayingHandler;
 		player.DecoderError += OnPlayerError;
 
 		// Subscribe to audio session interruptions
@@ -441,8 +456,16 @@ partial class AudioPlayer : IAudioPlayer
 		OnError(e);
 	}
 
-	void OnPlayerFinishedPlaying(object? sender, AVStatusEventArgs e)
+	void OnPlayerFinishedPlaying(AVAudioPlayer finishedPlayer, int generation, AVStatusEventArgs e)
 	{
-		PlaybackEnded?.Invoke(this, e);
+		NSRunLoop.Main.BeginInvokeOnMainThread(() =>
+		{
+			if (!isDisposed &&
+				generation == Volatile.Read(ref playerGeneration) &&
+				ReferenceEquals(player, finishedPlayer))
+			{
+				PlaybackEnded?.Invoke(this, e);
+			}
+		});
 	}
 }

--- a/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
+++ b/src/Plugin.Maui.Audio/AudioPlayer/AudioPlayer.windows.cs
@@ -258,16 +258,16 @@ partial class AudioPlayer : IAudioPlayer
 			return;
 		}
 
+		isDisposed = true;
+
 		if (disposing)
 		{
-			Stop();
-
 			player.MediaFailed -= OnError;
 			player.MediaEnded -= OnPlaybackEnded;
+			player.Pause();
+			Seek(0);
 			player.Dispose();
 		}
-
-		isDisposed = true;
 	}
 }
 
@@ -285,4 +285,3 @@ public class MediaPlayerFailedEventArgsWrapper : EventArgs
 		ErrorMessage = args.Error.ToString();
 	}
 }
-


### PR DESCRIPTION
## Summary
- defer iOS/Mac Catalyst `PlaybackEnded` delivery until the native `AVAudioPlayer` delegate callback has returned
- suppress queued completion events after source changes, restarts, stops, or disposal
- avoid raising `PlaybackEnded` during internal disposal on Apple and Windows, and make platform disposal reentrancy-safe
- document the safe unsubscribe-before-dispose pattern for short sounds

## Verification
- `dotnet build src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj -c Release`
- `dotnet build src/Plugin.Maui.Audio/Plugin.Maui.Audio.csproj -c Release -p:TargetFrameworks=net10.0-windows10.0.19041.0 -p:EnableWindowsTargeting=true`
- independent final reviews with Claude Sonnet 5, Gemini 3.1 Pro, and GPT-5.4: no findings

A direct simulator reproduction was attempted, but the installed Xcode 26.6 SDK requires an iOS 26.5 simulator runtime that is not installed on this machine. The .NET iOS binding source confirms the reported failure condition: it throws when the player handle is cleared before `FinishedPlaying` returns.

Fixes #216